### PR TITLE
Replace UI-thread dependent AsyncTask with plain Thread

### DIFF
--- a/Autobahn/src/de/tavendo/autobahn/WebSocketConnection.java
+++ b/Autobahn/src/de/tavendo/autobahn/WebSocketConnection.java
@@ -24,7 +24,6 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.channels.SocketChannel;
 
-import android.os.AsyncTask;
 import android.os.Handler;
 import android.os.HandlerThread;
 import android.os.Message;
@@ -58,77 +57,72 @@ public class WebSocketConnection implements WebSocket {
    private boolean mActive;
    private boolean mPrevConnected;
 
-   /**
-    * Asynch socket connector.
-    */
-   private class WebSocketConnector extends AsyncTask<Void, Void, String> {
+	/**
+	 * Asynchronous socket connector.
+	 */
+	private class WebSocketConnector extends Thread {
 
-      @Override
-      protected String doInBackground(Void... params) {
+		public void run() {
+			Thread.currentThread().setName("WebSocketConnector");
 
-         Thread.currentThread().setName("WebSocketConnector");
+			/*
+			 * connect TCP socket
+			 */
+			try {
+				mTransportChannel = SocketChannel.open();
 
-         // connect TCP socket
-         // http://developer.android.com/reference/java/nio/channels/SocketChannel.html
-         //
-         try {
-            mTransportChannel = SocketChannel.open();
+				// the following will block until connection was established or
+				// an error occurred!
+				mTransportChannel.socket().connect(
+						new InetSocketAddress(mWsHost, mWsPort),
+						mOptions.getSocketConnectTimeout());
 
-            // the following will block until connection was established or an error occurred!
-            mTransportChannel.socket().connect(new InetSocketAddress(mWsHost, mWsPort), mOptions.getSocketConnectTimeout());
+				// before doing any data transfer on the socket, set socket
+				// options
+				mTransportChannel.socket().setSoTimeout(
+						mOptions.getSocketReceiveTimeout());
+				mTransportChannel.socket().setTcpNoDelay(
+						mOptions.getTcpNoDelay());
 
-            // before doing any data transfer on the socket, set socket options
-            mTransportChannel.socket().setSoTimeout(mOptions.getSocketReceiveTimeout());
-            mTransportChannel.socket().setTcpNoDelay(mOptions.getTcpNoDelay());
+			} catch (IOException e) {
+				onClose(WebSocketConnectionHandler.CLOSE_CANNOT_CONNECT,
+						e.getMessage());
+				return;
+			}
 
-            return null;
+			if (mTransportChannel.isConnected()) {
 
-         } catch (IOException e) {
+				try {
 
-            return e.getMessage();
-         }
-      }
+					// create & start WebSocket reader
+					createReader();
 
-      @Override
-      protected void onPostExecute(String reason) {
+					// create & start WebSocket writer
+					createWriter();
 
-         if (reason != null) {
+					// start WebSockets handshake
+					WebSocketMessage.ClientHandshake hs = new WebSocketMessage.ClientHandshake(
+							mWsHost + ":" + mWsPort);
+					hs.mPath = mWsPath;
+					hs.mQuery = mWsQuery;
+					hs.mSubprotocols = mWsSubprotocols;
+					mWriter.forward(hs);
 
-            onClose(WebSocketConnectionHandler.CLOSE_CANNOT_CONNECT, reason);
+					mPrevConnected = true;
 
-         } else if (mTransportChannel.isConnected()) {
+				} catch (Exception e) {
+					onClose(WebSocketConnectionHandler.CLOSE_INTERNAL_ERROR,
+							e.getMessage());
+					return;
+				}
+			} else {
+				onClose(WebSocketConnectionHandler.CLOSE_CANNOT_CONNECT,
+						"Could not connect to WebSocket server");
+				return;
+			}
+		}
 
-            try {
-
-               // create & start WebSocket reader
-               createReader();
-
-               // create & start WebSocket writer
-               createWriter();
-
-               // start WebSockets handshake
-               WebSocketMessage.ClientHandshake hs = new WebSocketMessage.ClientHandshake(mWsHost + ":" + mWsPort);
-               hs.mPath = mWsPath;
-               hs.mQuery = mWsQuery;
-               hs.mSubprotocols = mWsSubprotocols;
-               mWriter.forward(hs);
-               
-               mPrevConnected = true;
-
-            } catch (Exception e) {
-
-               onClose(WebSocketConnectionHandler.CLOSE_INTERNAL_ERROR, e.getMessage());
-
-            }
-
-         } else {
-
-            onClose(WebSocketConnectionHandler.CLOSE_CANNOT_CONNECT, "could not connect to WebSockets server");
-         }
-      }
-
-   }
-
+	}
 
    public WebSocketConnection() {
       if (DEBUG) Log.d(TAG, "created");
@@ -285,7 +279,7 @@ public class WebSocketConnection implements WebSocket {
       mActive = true;
 
       // use asynch connector on short-lived background thread
-      new WebSocketConnector().execute();
+      new WebSocketConnector().start();
    }
 
 
@@ -305,7 +299,7 @@ public class WebSocketConnection implements WebSocket {
     */
    public boolean reconnect() {
 	   if (!isConnected() && (mWsUri != null)) {
-		   new WebSocketConnector().execute();
+		   new WebSocketConnector().start();
 		   return true;
 	   }
 	   return false;


### PR DESCRIPTION
WebSocketConnection#connect() used an AsyncTask to initialize the
TCP connection. Since AsyncTask#execute() _must_ be invoked from
the UI thread it wasn't possible to initialize the websocket from other
threads.
Use a normal Thread instead for the initialization.
