### PR TITLE
Small fixes previously discussed in forum

### DIFF
--- a/Autobahn/src/de/tavendo/autobahn/WampConnection.java
+++ b/Autobahn/src/de/tavendo/autobahn/WampConnection.java
@@ -332,10 +332,11 @@ public class WampConnection extends WebSocketConnection implements Wamp {
 
       if (!mSubs.containsKey(uri)) {
 
+         mSubs.put(uri, meta);
+
          WampMessage.Subscribe msg = new WampMessage.Subscribe(mOutgoingPrefixes.shrink(topicUri));
          mWriter.forward(msg);
       }
-      mSubs.put(uri, meta);
    }
 
 
@@ -378,6 +379,8 @@ public class WampConnection extends WebSocketConnection implements Wamp {
 
          WampMessage.Unsubscribe msg = new WampMessage.Unsubscribe(topicUri);
          mWriter.forward(msg);
+         
+         mSubs.remove(topicUri);
       }
    }
 
@@ -391,7 +394,8 @@ public class WampConnection extends WebSocketConnection implements Wamp {
 
          WampMessage.Unsubscribe msg = new WampMessage.Unsubscribe(topicUri);
          mWriter.forward(msg);
-     }
+      }
+      mSubs.clear();
    }
 
 


### PR DESCRIPTION
3 Small fixes: 1) subscription is now recorded before the subscription message is issued to the server, 2) subscription is removed locally after unsubscription message is issued to the server, 3) in global unsubscription the map is cleared after issuing all the unsubscription messages.

Regards,
Alejandro.
