### PR TITLE
Fixes to WampCra Implementation

### DIFF
--- a/Autobahn/src/de/tavendo/autobahn/WampCra.java
+++ b/Autobahn/src/de/tavendo/autobahn/WampCra.java
@@ -48,9 +48,18 @@ public interface WampCra extends Wamp {
      * @param authHandler   The handler to be invoked upon authentication completion.
      * @param authKey       The user Key for authentication.
      * @param authSecret    The user Secret for authentication.
+     */
+    public void authenticate(AuthHandler authHandler, String authKey, String authSecret);
+    
+    /**
+     * Authenticate the WAMP Session.
+     *
+     * @param authHandler   The handler to be invoked upon authentication completion.
+     * @param authKey       The user Key for authentication.
+     * @param authSecret    The user Secret for authentication.
      * @param authExtra     Zero, one or more extra arguments for the authentication.
      */
-    public void authenticate(AuthHandler authHandler, String authKey, String authSecret, Object... authExtra);
+    public void authenticate(AuthHandler authHandler, String authKey, String authSecret, Object authExtra);
     
     
 }

--- a/Autobahn/src/de/tavendo/autobahn/WampCraConnection.java
+++ b/Autobahn/src/de/tavendo/autobahn/WampCraConnection.java
@@ -31,8 +31,12 @@ import android.util.Log;
 
 public class WampCraConnection extends WampConnection implements WampCra {
 
-    public void authenticate(final AuthHandler authHandler, final String authKey, final String authSecret, Object... authExtra) {
-        call(Wamp.URI_WAMP_PROCEDURE + "authreq", String.class, new CallHandler(){
+    public void authenticate(final AuthHandler authHandler, final String authKey, final String authSecret){
+        authenticate(authHandler, authKey, authSecret, null);
+    }
+    
+    public void authenticate(final AuthHandler authHandler, final String authKey, final String authSecret, Object authExtra) {
+        CallHandler callHandler = new CallHandler(){
 
             public void onResult(Object challenge) {
                 
@@ -62,7 +66,11 @@ public class WampCraConnection extends WampConnection implements WampCra {
                 authHandler.onAuthError(errorUri,errorDesc);                
             }
             
-        }, authKey, authExtra);
+        };
+        if (authExtra != null)
+            call(Wamp.URI_WAMP_PROCEDURE + "authreq", String.class, callHandler, authKey, authExtra);
+        else
+            call(Wamp.URI_WAMP_PROCEDURE + "authreq", String.class, callHandler, authKey);
     }
 
     public String authSignature(String authChallenge, String authSecret) throws SignatureException{


### PR DESCRIPTION
Hi, I realized that I had a bug on my WampCra implementation, when using auth extra arguments:
AuthExtra objects where passed thru a variable argument, and that in Java is an array, regardles if you pass only one object, it always wraps it in an array. So jackson would encode that not in a Json but into a Json array, and therefore, the python server would receive a list, instead of a dictionary, and auth extra is expected to be a dict.

So, to solve it, I extended the interface, making two different functions, one for authentication with extras and one without. And also I implemented the interface of course.

Well that's all, regards,
Alejandro.
