### PR TITLE
Specify a single protcol as "protocol1" instead of, previously, "protocol1,"

### DIFF
--- a/Autobahn/src/de/tavendo/autobahn/WebSocketWriter.java
+++ b/Autobahn/src/de/tavendo/autobahn/WebSocketWriter.java
@@ -173,7 +173,9 @@ public class WebSocketWriter extends Handler {
          mBuffer.write("Sec-WebSocket-Protocol: ");
          for (int i = 0; i < message.mSubprotocols.length; ++i) {
             mBuffer.write(message.mSubprotocols[i]);
-            mBuffer.write(", ");
+            if (i != message.mSubprotocols.length-1) {
+               mBuffer.write(", ");
+            }
          }
          mBuffer.crlf();
       }


### PR DESCRIPTION
Hello I've been trying to implement WebSocket client side which needed to send string "text-stream" as sub-protocol in handshake key. But WebSocketWriter send "text-stream," So I suggest to add in the method sendClientHandshake()

if (i != message.mSubprotocols.length - 1) {
mBuffer.write(", ");
}

to add comma only for separate strings.
