### PR TITLE
Ensuring that WebSocketConnection#disconnect sends appropriate message on close.

### DIFF
--- a/Autobahn/pom.xml
+++ b/Autobahn/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>de.tavendo</groupId>
     <artifactId>autobahn-android</artifactId>
-    <version>0.5.2-2014-01-27</version>
+    <version>0.5.2-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>AutobahnAndroid</name>

--- a/Autobahn/src/de/tavendo/autobahn/WebSocketConnection.java
+++ b/Autobahn/src/de/tavendo/autobahn/WebSocketConnection.java
@@ -438,6 +438,8 @@ public class WebSocketConnection implements WebSocket {
                final int tavendoCloseCode = (close.mCode == 1000) ? ConnectionHandler.CLOSE_NORMAL : ConnectionHandler.CLOSE_CONNECTION_LOST;
                onClose(tavendoCloseCode, close.mReason);
 
+               mWriter.forward(new WebSocketMessage.Close(1000));
+
             } else if (msg.obj instanceof WebSocketMessage.ServerHandshake) {
 
                WebSocketMessage.ServerHandshake serverHandshake = (WebSocketMessage.ServerHandshake) msg.obj;


### PR DESCRIPTION
Ensuring that WebSocketConnection#disconnect sends ConnectionHandler#CLOSE_NORMAL instead of ConnectionHandler#CLOSE_CONNECTION when the client explicitly closes the connection.

On a side note, why are the close constants in WebSocket.ConnectionHandler different from those specified for the WebSocket Protocol - http://tools.ietf.org/html/rfc6455#section-7.4
It seems to me that it would clarify and simplify Autobahn if it were to use the protocol close constants.
