### PR TITLE
send raw path and query URI parts in HTTP request

### DIFF
--- a/Autobahn/src/de/tavendo/autobahn/WebSocketConnection.java
+++ b/Autobahn/src/de/tavendo/autobahn/WebSocketConnection.java
@@ -256,16 +256,16 @@ public class WebSocketConnection implements WebSocket {
             mWsHost = mWsUri.getHost();
          }
 
-         if (mWsUri.getPath() == null || mWsUri.getPath().equals("")) {
+         if (mWsUri.getRawPath() == null || mWsUri.getRawPath().equals("")) {
             mWsPath = "/";
          } else {
-            mWsPath = mWsUri.getPath();
+            mWsPath = mWsUri.getRawPath();
          }
 
-         if (mWsUri.getQuery() == null || mWsUri.getQuery().equals("")) {
+         if (mWsUri.getRawQuery() == null || mWsUri.getRawQuery().equals("")) {
             mWsQuery = null;
          } else {
-            mWsQuery = mWsUri.getQuery();
+            mWsQuery = mWsUri.getRawQuery();
          }
 
       } catch (URISyntaxException e) {


### PR DESCRIPTION
Using decoded instead of encoded URI components can lead to invalid HTTP
requests, and could be used to modify request headers.
