### PR TITLE
Flush the OutputStream on write to ensure messages are not batched.

### DIFF
--- a/Autobahn/src/de/tavendo/autobahn/WebSocketWriter.java
+++ b/Autobahn/src/de/tavendo/autobahn/WebSocketWriter.java
@@ -400,6 +400,7 @@ public class WebSocketWriter extends Handler {
             @SuppressWarnings("unused")
             int written = mSocket.write(mBuffer.getBuffer());
          }
+         mSocket.socket().getOutputStream().flush(); // Setting TCP_NODELAY does not seem to ensure messages are always written immediately.
 
       } catch (SocketException e) {
     	  


### PR DESCRIPTION
Was getting occasional messages not being sent until the connection was closed.

Setting TCP_NODELAY does not seem to ensure messages are always written immediately.
But flushing the OutputStream seems to have reduced the incidence.

It's possible that my issue is really network contention and the TCP messages are being held up by the transport layer. I have some evidence for that, but calling flush definitely stopped the messages being batched.
