### PR TITLE
Fix TestClient

### DIFF
--- a/autobahn/build.gradle
+++ b/autobahn/build.gradle
@@ -6,7 +6,7 @@ android {
     useLibrary 'org.apache.http.legacy'
 
     defaultConfig {
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 25
     }
 

--- a/autobahn/src/main/java/io/crossbar/autobahn/WebSocketConnection.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/WebSocketConnection.java
@@ -109,11 +109,11 @@ public class WebSocketConnection implements WebSocket {
 
                 try {
 
-                    // create & start WebSocket writer
-                    createWriter();
-
                     // create & start WebSocket reader
                     createReader();
+
+                    // create & start WebSocket writer
+                    createWriter();
 
                     // start WebSockets handshake
                     WebSocketMessage.ClientHandshake hs = new WebSocketMessage.ClientHandshake(
@@ -443,7 +443,8 @@ public class WebSocketConnection implements WebSocket {
                     final int crossbarCloseCode = (close.mCode == 1000) ? ConnectionHandler.CLOSE_NORMAL : ConnectionHandler.CLOSE_CONNECTION_LOST;
 
                     if (mActive) {
-                        mWriter.forward(new WebSocketMessage.Close(1000));
+                        // We have received a close frame, lets clean.
+                        disconnect();
                     } else {
                         // we've initiated disconnect, so ready to close the channel
                         try {

--- a/autobahn/src/main/java/io/crossbar/autobahn/WebSocketReader.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/WebSocketReader.java
@@ -685,11 +685,14 @@ public class WebSocketReader extends Thread {
 
         } catch (SocketException e) {
 
-            if (DEBUG) Log.d(TAG, "run() : SocketException (" + e.toString() + ")");
+            // BufferedInputStream throws when the socket is closed,
+            // eat the exception if we are already in STATE_CLOSED.
+            if (mState != STATE_CLOSED) {
+                if (DEBUG) Log.d(TAG, "run() : SocketException (" + e.toString() + ")");
 
-            // wrap the exception and notify master
-            notify(new WebSocketMessage.ConnectionLost());
-            ;
+                // wrap the exception and notify master
+                notify(new WebSocketMessage.ConnectionLost());
+            }
 
         } catch (Exception e) {
 

--- a/autobahn/src/main/java/io/crossbar/autobahn/WebSocketWriter.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/WebSocketWriter.java
@@ -134,8 +134,9 @@ public class WebSocketWriter extends Handler {
      *                this class).
      */
     public void forward(Object message) {
-        // We have already quite, we are no longer sending messages.
+        // We have already quit, we are no longer sending messages.
         if (!mActive) {
+            if (DEBUG) Log.d(TAG, "We have already quite, not processing further messages");
             return;
         }
         Message msg = obtainMessage();

--- a/autobahn/src/main/java/io/crossbar/autobahn/WebSocketWriter.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/WebSocketWriter.java
@@ -69,6 +69,12 @@ public class WebSocketWriter extends Handler {
     /// The send buffer that holds data to send on socket.
     private BufferedOutputStream mBufferedOutputStream;
 
+    /// The tcp socket
+    private Socket mSocket;
+
+    /// Is Active.
+    private boolean mActive;
+
 
     /**
      * Create new WebSockets background writer.
@@ -86,7 +92,9 @@ public class WebSocketWriter extends Handler {
         mLooper = looper;
         mMaster = master;
         mOptions = options;
+        mSocket = socket;
         mBufferedOutputStream = new BufferedOutputStream(socket.getOutputStream(), options.getMaxFramePayloadSize() + 14);
+        mActive = true;
 
         if (DEBUG) Log.d(TAG, "created");
     }
@@ -126,6 +134,10 @@ public class WebSocketWriter extends Handler {
      *                this class).
      */
     public void forward(Object message) {
+        // We have already quite, we are no longer sending messages.
+        if (!mActive) {
+            return;
+        }
         Message msg = obtainMessage();
         msg.obj = message;
         sendMessage(msg);
@@ -402,6 +414,7 @@ public class WebSocketWriter extends Handler {
             }
             mBufferedOutputStream.write(payload, offset, length);
         }
+        mBufferedOutputStream.flush();
     }
 
 
@@ -417,10 +430,13 @@ public class WebSocketWriter extends Handler {
         try {
 
             // process message from master
+            Log.d(TAG, msg.obj.toString());
             processMessage(msg.obj);
 
             // send out buffered data
-            mBufferedOutputStream.flush();
+            if (mActive && mSocket.isConnected()) {
+                mBufferedOutputStream.flush();
+            }
 
         } catch (SocketException e) {
 
@@ -478,10 +494,9 @@ public class WebSocketWriter extends Handler {
         } else if (msg instanceof WebSocketMessage.Quit) {
 
             mLooper.quit();
+            mActive = false;
 
             if (DEBUG) Log.d(TAG, "ended");
-
-            return;
 
         } else {
 

--- a/autobahn/src/main/java/io/crossbar/autobahn/WebSocketWriter.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/WebSocketWriter.java
@@ -415,7 +415,6 @@ public class WebSocketWriter extends Handler {
             }
             mBufferedOutputStream.write(payload, offset, length);
         }
-        mBufferedOutputStream.flush();
     }
 
 
@@ -431,7 +430,6 @@ public class WebSocketWriter extends Handler {
         try {
 
             // process message from master
-            Log.d(TAG, msg.obj.toString());
             processMessage(msg.obj);
 
             // send out buffered data

--- a/demo-gallery/build.gradle
+++ b/demo-gallery/build.gradle
@@ -10,7 +10,7 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 25
     }
     buildTypes {

--- a/demo-gallery/src/main/AndroidManifest.xml
+++ b/demo-gallery/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
 
     <application
         android:allowBackup="true"
+        android:largeHeap="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:supportsRtl="true"

--- a/demo-gallery/src/main/java/io/crossbar/autobahn/demogallery/TestSuiteClientActivity.java
+++ b/demo-gallery/src/main/java/io/crossbar/autobahn/demogallery/TestSuiteClientActivity.java
@@ -80,8 +80,8 @@ public class TestSuiteClientActivity extends AppCompatActivity implements View.O
 
         mOptions = new WebSocketOptions();
         mOptions.setReceiveTextMessagesRaw(true);
-        mOptions.setMaxMessagePayloadSize(4 * 1024 * 1024);
-        mOptions.setMaxFramePayloadSize(4 * 1024 * 1024);
+        mOptions.setMaxMessagePayloadSize(16 * 1024 * 1024);
+        mOptions.setMaxFramePayloadSize(16 * 1024 * 1024);
 
         mHandler = new Handler();
         mTestRunner = new Runnable() {

--- a/demo-gallery/src/main/java/io/crossbar/autobahn/demogallery/TestSuiteClientActivity.java
+++ b/demo-gallery/src/main/java/io/crossbar/autobahn/demogallery/TestSuiteClientActivity.java
@@ -140,7 +140,7 @@ public class TestSuiteClientActivity extends AppCompatActivity implements View.O
 
                     @Override
                     public void onClose(int code, String reason) {
-                        // XXX om26er. Temporary workaround a bug where onClose is closed multiple times,
+                        // XXX om26er. Temporary workaround a bug where onClose is called multiple times,
                         // causing the test run counter to go haywire.
                         if (!receivedClose[0]) {
                             receivedClose[0] = true;

--- a/demo-gallery/src/main/java/io/crossbar/autobahn/demogallery/TestSuiteClientActivity.java
+++ b/demo-gallery/src/main/java/io/crossbar/autobahn/demogallery/TestSuiteClientActivity.java
@@ -118,6 +118,7 @@ public class TestSuiteClientActivity extends AppCompatActivity implements View.O
     }
 
     private void runTest() throws WebSocketException {
+        final boolean[] receivedClose = new boolean[1];
         final WebSocketConnection webSocket = new WebSocketConnection();
         webSocket.connect(mWsUri.getText() + "/runCase?case=" + currentCase + "&agent=" + mAgent.getText(),
                 new WebSocketConnectionHandler() {
@@ -139,10 +140,14 @@ public class TestSuiteClientActivity extends AppCompatActivity implements View.O
 
                     @Override
                     public void onClose(int code, String reason) {
-                        System.out.println("RAN TEST: " + reason);
-                        mStatusLine.setText("Test case " + currentCase + "/" + lastCase + " finished.");
-                        currentCase += 1;
-                        processNext();
+                        // XXX om26er. Temporary workaround a bug where onClose is closed multiple times,
+                        // causing the test run counter to go haywire.
+                        if (!receivedClose[0]) {
+                            receivedClose[0] = true;
+                            mStatusLine.setText("Test case " + currentCase + "/" + lastCase + " finished.");
+                            currentCase += 1;
+                            processNext();
+                        }
                     }
                 }, mOptions);
     }
@@ -181,7 +186,6 @@ public class TestSuiteClientActivity extends AppCompatActivity implements View.O
 
                     @Override
                     public void onClose(int code, String reason) {
-                        System.out.println("GOT CASE COUNT");
                         mStatusLine.setText("Ok, will run " + lastCase + " cases.");
                         currentCase += 1;
                         processNext();


### PR DESCRIPTION
Fix testclient to add interval between each run, it seems previously we were trying to reuse the same WebSocketConnection object, which is bad in so many ways(though that helped us discover a few leaks). To fix that, I am now creating a new WebSocketConnection object for each test, this is much stable than the previous approach. Though it seems Android chickens out due to lack of resources when we create too many threads. So the fix was to wait between each test so that the garbage collector does it job.

The bug that I discovered is that if our client receives a message frame after receiving a closeFrame, we are not ignoring that message and rather end up calling the onClose callback again, with "lost connection", I have fixed that partially but its not fully fixed as there are still cases that can cause that issue.

I have again bumped the minimum Android requirement because requesting a larger heapSize is a feature that is supported on API level 14+