### PR TITLE
Don't process further messages once a close frame is received

### DIFF
--- a/autobahn/src/main/java/io/crossbar/autobahn/WebSocketReader.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/WebSocketReader.java
@@ -654,8 +654,13 @@ class WebSocketReader extends Thread {
         try {
             do {
                 // blocking read on socket
-                int len = mBufferedStream.read(mMessageData, mPosition, mMessageData.length - mPosition);
-                mPosition += len;
+                int len = 0;
+                if (mBufferedStream.available() > 0) {
+                    len = mBufferedStream.read(mMessageData, mPosition, mMessageData.length - mPosition);
+                    mPosition += len;
+                }
+//                int len = mBufferedStream.read(mMessageData, mPosition, mMessageData.length - mPosition);
+//                mPosition += len;
                 if (len > 0) {
 
                     // process buffered data
@@ -688,7 +693,7 @@ class WebSocketReader extends Thread {
 
             // BufferedInputStream throws when the socket is closed,
             // eat the exception if we are already in STATE_CLOSED.
-            if (mState != STATE_CLOSED) {
+            if (mState != STATE_CLOSED && !mSocket.isClosed()) {
                 if (DEBUG) Log.d(TAG, "run() : SocketException (" + e.toString() + ")");
 
                 // wrap the exception and notify master

--- a/autobahn/src/main/java/io/crossbar/autobahn/WebSocketReader.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/WebSocketReader.java
@@ -654,11 +654,8 @@ class WebSocketReader extends Thread {
         try {
             do {
                 // blocking read on socket
-                int len = 0;
-                if (mBufferedStream.available() > 0) {
-                    len = mBufferedStream.read(mMessageData, mPosition, mMessageData.length - mPosition);
-                    mPosition += len;
-                }
+                int len = mBufferedStream.read(mMessageData, mPosition, mMessageData.length - mPosition);
+                mPosition += len;
                 if (len > 0) {
 
                     // process buffered data

--- a/autobahn/src/main/java/io/crossbar/autobahn/WebSocketReader.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/WebSocketReader.java
@@ -659,8 +659,6 @@ class WebSocketReader extends Thread {
                     len = mBufferedStream.read(mMessageData, mPosition, mMessageData.length - mPosition);
                     mPosition += len;
                 }
-//                int len = mBufferedStream.read(mMessageData, mPosition, mMessageData.length - mPosition);
-//                mPosition += len;
                 if (len > 0) {
 
                     // process buffered data

--- a/autobahn/src/main/java/io/crossbar/autobahn/WebSocketWriter.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/WebSocketWriter.java
@@ -432,7 +432,8 @@ public class WebSocketWriter extends Handler {
             processMessage(msg.obj);
 
             // send out buffered data
-            if (mActive && mSocket.isConnected()) {
+
+            if (mActive && mSocket.isConnected() && !mSocket.isClosed()) {
                 mBufferedOutputStream.flush();
             }
 

--- a/demo-gallery/src/main/java/io/crossbar/autobahn/demogallery/TestSuiteClientActivity.java
+++ b/demo-gallery/src/main/java/io/crossbar/autobahn/demogallery/TestSuiteClientActivity.java
@@ -118,7 +118,6 @@ public class TestSuiteClientActivity extends AppCompatActivity implements View.O
     }
 
     private void runTest() throws WebSocketException {
-//        final boolean[] receivedClose = new boolean[1];
         final WebSocketConnection webSocket = new WebSocketConnection();
         webSocket.connect(mWsUri.getText() + "/runCase?case=" + currentCase + "&agent=" + mAgent.getText(),
                 new WebSocketConnectionHandler() {
@@ -140,8 +139,6 @@ public class TestSuiteClientActivity extends AppCompatActivity implements View.O
 
                     @Override
                     public void onClose(int code, String reason) {
-                        // XXX om26er. Temporary workaround a bug where onClose is called multiple times,
-                        // causing the test run counter to go haywire.
                         mStatusLine.setText("Test case " + currentCase + "/" + lastCase + " finished.");
                         currentCase += 1;
                         processNext();

--- a/demo-gallery/src/main/java/io/crossbar/autobahn/demogallery/TestSuiteClientActivity.java
+++ b/demo-gallery/src/main/java/io/crossbar/autobahn/demogallery/TestSuiteClientActivity.java
@@ -118,7 +118,7 @@ public class TestSuiteClientActivity extends AppCompatActivity implements View.O
     }
 
     private void runTest() throws WebSocketException {
-        final boolean[] receivedClose = new boolean[1];
+//        final boolean[] receivedClose = new boolean[1];
         final WebSocketConnection webSocket = new WebSocketConnection();
         webSocket.connect(mWsUri.getText() + "/runCase?case=" + currentCase + "&agent=" + mAgent.getText(),
                 new WebSocketConnectionHandler() {
@@ -142,12 +142,9 @@ public class TestSuiteClientActivity extends AppCompatActivity implements View.O
                     public void onClose(int code, String reason) {
                         // XXX om26er. Temporary workaround a bug where onClose is called multiple times,
                         // causing the test run counter to go haywire.
-                        if (!receivedClose[0]) {
-                            receivedClose[0] = true;
-                            mStatusLine.setText("Test case " + currentCase + "/" + lastCase + " finished.");
-                            currentCase += 1;
-                            processNext();
-                        }
+                        mStatusLine.setText("Test case " + currentCase + "/" + lastCase + " finished.");
+                        currentCase += 1;
+                        processNext();
                     }
                 }, mOptions);
     }


### PR DESCRIPTION
Fixes a bunch of bugs, especially around leaks where the Socket was not closed, or where the main Handler had called quit.

Also removes the hacks that I had out in the TestSuiteClientActivity.