### PR TITLE
Ensure cleanup of threads

### DIFF
--- a/autobahn/src/main/java/io/crossbar/autobahn/WebSocketMessage.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/WebSocketMessage.java
@@ -157,6 +157,7 @@ public class WebSocketMessage {
 
         public int mCode;
         public String mReason;
+        public boolean mIsReply;
 
         Close() {
             mCode = -1;
@@ -168,9 +169,19 @@ public class WebSocketMessage {
             mReason = null;
         }
 
+        Close(int code, boolean isReply) {
+            mIsReply = isReply;
+        }
+
         Close(int code, String reason) {
             mCode = code;
             mReason = reason;
+        }
+
+        Close(int code, String reason, boolean isReply) {
+            mCode = code;
+            mReason = reason;
+            mIsReply = isReply;
         }
     }
 

--- a/autobahn/src/main/java/io/crossbar/autobahn/WebSocketMessage.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/WebSocketMessage.java
@@ -170,6 +170,7 @@ public class WebSocketMessage {
             mReason = null;
         }
 
+        // For local use only.
         Close(int code, boolean isReply) {
             mIsReply = isReply;
         }
@@ -177,12 +178,6 @@ public class WebSocketMessage {
         Close(int code, String reason) {
             mCode = code;
             mReason = reason;
-        }
-
-        Close(int code, String reason, boolean isReply) {
-            mCode = code;
-            mReason = reason;
-            mIsReply = isReply;
         }
     }
 

--- a/autobahn/src/main/java/io/crossbar/autobahn/WebSocketMessage.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/WebSocketMessage.java
@@ -157,6 +157,7 @@ public class WebSocketMessage {
 
         public int mCode;
         public String mReason;
+        // Not to be delivered on the wire, only for local use.
         public boolean mIsReply;
 
         Close() {

--- a/autobahn/src/main/java/io/crossbar/autobahn/WebSocketMessage.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/WebSocketMessage.java
@@ -172,11 +172,18 @@ public class WebSocketMessage {
 
         // For local use only.
         Close(int code, boolean isReply) {
+            mCode = code;
             mIsReply = isReply;
         }
 
         Close(int code, String reason) {
             mCode = code;
+            mReason = reason;
+        }
+
+        Close(int code, String reason, boolean isReply) {
+            mCode = code;
+            mIsReply = isReply;
             mReason = reason;
         }
     }

--- a/autobahn/src/main/java/io/crossbar/autobahn/WebSocketReader.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/WebSocketReader.java
@@ -673,6 +673,7 @@ class WebSocketReader extends Thread {
                     if (DEBUG) Log.d(TAG, "run() : ConnectionLost");
 
                     notify(new WebSocketMessage.ConnectionLost());
+
                     mStopped = true;
                 }
             } while (!mStopped);

--- a/autobahn/src/main/java/io/crossbar/autobahn/WebSocketReader.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/WebSocketReader.java
@@ -670,9 +670,11 @@ class WebSocketReader extends Thread {
 
                 } else if (len < 0) {
 
-                    if (DEBUG) Log.d(TAG, "run() : ConnectionLost");
+                    if (mState != STATE_CLOSED) {
+                        if (DEBUG) Log.d(TAG, "run() : ConnectionLost");
 
-                    notify(new WebSocketMessage.ConnectionLost());
+                        notify(new WebSocketMessage.ConnectionLost());
+                    }
 
                     mStopped = true;
                 }

--- a/autobahn/src/main/java/io/crossbar/autobahn/WebSocketReader.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/WebSocketReader.java
@@ -336,6 +336,12 @@ class WebSocketReader extends Thread {
                             }
                         }
                         onClose(code, reason);
+                        // We have received a close, so lets set the state as early as possible.
+                        // It seems that Handler() has a lag to deliver a message, so if the onClose
+                        // is sent to master and just after that the other peer closes the socket,
+                        // BufferedInputReader.read() will throw an exception which results in
+                        // our code sending a ConnectionLost() message to master.
+                        mState = STATE_CLOSED;
 
                     } else if (mFrameHeader.mOpcode == 9) {
                         // dispatch WS ping
@@ -665,16 +671,13 @@ class WebSocketReader extends Thread {
 
                 } else if (mState == STATE_CLOSED) {
 
-                    notify(new WebSocketMessage.Close(1000)); // Connection has been closed normally
                     mStopped = true;
 
                 } else if (len < 0) {
 
-                    if (mState != STATE_CLOSED) {
-                        if (DEBUG) Log.d(TAG, "run() : ConnectionLost");
+                    if (DEBUG) Log.d(TAG, "run() : ConnectionLost");
 
-                        notify(new WebSocketMessage.ConnectionLost());
-                    }
+                    notify(new WebSocketMessage.ConnectionLost());
 
                     mStopped = true;
                 }

--- a/autobahn/src/main/java/io/crossbar/autobahn/WebSocketWriter.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/WebSocketWriter.java
@@ -443,7 +443,7 @@ public class WebSocketWriter extends Handler {
             if (msg.obj instanceof WebSocketMessage.Close) {
                 WebSocketMessage.Close closeMessage = (WebSocketMessage.Close) msg.obj;
                 if (closeMessage.mIsReply) {
-                    notify(closeMessage);
+                    notify(new WebSocketMessage.Close(closeMessage.mCode, closeMessage.mReason, true));
                 }
             }
 

--- a/autobahn/src/main/java/io/crossbar/autobahn/WebSocketWriter.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/WebSocketWriter.java
@@ -136,7 +136,7 @@ public class WebSocketWriter extends Handler {
     public void forward(Object message) {
         // We have already quit, we are no longer sending messages.
         if (!mActive) {
-            if (DEBUG) Log.d(TAG, "We have already quite, not processing further messages");
+            if (DEBUG) Log.d(TAG, "We have already quit, not processing further messages");
             return;
         }
         Message msg = obtainMessage();
@@ -437,6 +437,16 @@ public class WebSocketWriter extends Handler {
             if (mActive && mSocket.isConnected() && !mSocket.isClosed()) {
                 mBufferedOutputStream.flush();
             }
+
+            // Check if the message that we sent was a close frame and was a reply
+            // to a closing handshake, if so, then notify master to close the socket.
+            if (msg.obj instanceof WebSocketMessage.Close) {
+                WebSocketMessage.Close closeMessage = (WebSocketMessage.Close) msg.obj;
+                if (closeMessage.mIsReply) {
+                    notify(closeMessage);
+                }
+            }
+
 
         } catch (SocketException e) {
 

--- a/demo-gallery/src/main/java/io/crossbar/autobahn/demogallery/TestSuiteClientActivity.java
+++ b/demo-gallery/src/main/java/io/crossbar/autobahn/demogallery/TestSuiteClientActivity.java
@@ -28,7 +28,6 @@ package io.crossbar.autobahn.demogallery;
 
 import android.content.SharedPreferences;
 import android.os.Bundle;
-import android.os.Handler;
 import android.support.v7.app.AppCompatActivity;
 import android.view.View;
 import android.widget.Button;
@@ -41,8 +40,6 @@ import io.crossbar.autobahn.WebSocketException;
 import io.crossbar.autobahn.WebSocketOptions;
 
 public class TestSuiteClientActivity extends AppCompatActivity implements View.OnClickListener {
-
-    private static final String TAG = TestSuiteClientActivity.class.getName();
 
     private static final String PREFS_NAME = "AutobahnAndroidTestsuiteClient";
 
@@ -57,9 +54,6 @@ public class TestSuiteClientActivity extends AppCompatActivity implements View.O
     private int lastCase;
 
     private WebSocketOptions mOptions;
-
-    private Handler mHandler;
-    private Runnable mTestRunner;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -82,18 +76,6 @@ public class TestSuiteClientActivity extends AppCompatActivity implements View.O
         mOptions.setReceiveTextMessagesRaw(true);
         mOptions.setMaxMessagePayloadSize(16 * 1024 * 1024);
         mOptions.setMaxFramePayloadSize(16 * 1024 * 1024);
-
-        mHandler = new Handler();
-        mTestRunner = new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    runTest();
-                } catch (WebSocketException e) {
-                    e.printStackTrace();
-                }
-            }
-        };
     }
 
     private void loadPrefs() {
@@ -118,7 +100,6 @@ public class TestSuiteClientActivity extends AppCompatActivity implements View.O
     }
 
     private void runTest() throws WebSocketException {
-//        final boolean[] receivedClose = new boolean[1];
         final WebSocketConnection webSocket = new WebSocketConnection();
         webSocket.connect(mWsUri.getText() + "/runCase?case=" + currentCase + "&agent=" + mAgent.getText(),
                 new WebSocketConnectionHandler() {
@@ -140,8 +121,6 @@ public class TestSuiteClientActivity extends AppCompatActivity implements View.O
 
                     @Override
                     public void onClose(int code, String reason) {
-                        // XXX om26er. Temporary workaround a bug where onClose is called multiple times,
-                        // causing the test run counter to go haywire.
                         mStatusLine.setText("Test case " + currentCase + "/" + lastCase + " finished.");
                         currentCase += 1;
                         processNext();
@@ -160,7 +139,6 @@ public class TestSuiteClientActivity extends AppCompatActivity implements View.O
 
                     @Override
                     public void onClose(int code, String reason) {
-                        System.out.println("CLOSED: " + reason);
                         mStatusLine.setText("Test reports updated. Finished.");
                         mStart.setEnabled(true);
                     }
@@ -195,7 +173,7 @@ public class TestSuiteClientActivity extends AppCompatActivity implements View.O
             if (currentCase == 0) {
                 queryCaseCount();
             } else if (currentCase <= lastCase) {
-                mHandler.postDelayed(mTestRunner, 250);
+                runTest();
             } else {
                 updateReport();
             }


### PR DESCRIPTION
- Cleanup reader and writer threads at the "right" time.
- Due to above fixes, TestSuiteClient no longer have to wait between each test.