### PR TITLE
Build without Android support

### DIFF
--- a/autobahn/build.gradle
+++ b/autobahn/build.gradle
@@ -1,25 +1,41 @@
-apply plugin: 'com.android.library'
-android {
-    compileSdkVersion 26
-    buildToolsVersion "25.0.2"
-    useLibrary 'org.apache.http.legacy'
+String PLUGIN_ANDROID = "com.android.library"
+String PLUGIN_JAVA = "java"
 
-    defaultConfig {
-        minSdkVersion 24
-        targetSdkVersion 26
-    }
+apply plugin: PLUGIN_ANDROID
 
-    buildTypes {
-        release {
-            minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
+if (plugins.hasPlugin(PLUGIN_ANDROID)) {
+    android {
+        compileSdkVersion 26
+        buildToolsVersion "25.0.2"
+        useLibrary 'org.apache.http.legacy'
+
+        defaultConfig {
+            minSdkVersion 24
+            targetSdkVersion 26
+        }
+
+        buildTypes {
+            release {
+                minifyEnabled false
+                proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
+            }
+        }
+
+        compileOptions {
+            sourceCompatibility JavaVersion.VERSION_1_8
+            targetCompatibility JavaVersion.VERSION_1_8
         }
     }
-
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+} else if (plugins.hasPlugin(PLUGIN_JAVA)) {
+    sourceSets {
+        main {
+            java {
+                include 'io/crossbar/autobahn/wamp/**'
+            }
+        }
     }
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
 }
 
 dependencies {

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/Playground.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/Playground.java
@@ -1,4 +1,4 @@
-package io.crossbar.autobahn.demogallery;
+package io.crossbar.autobahn.wamp;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -6,8 +6,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
-import io.crossbar.autobahn.wamp.NettyTransport;
-import io.crossbar.autobahn.wamp.Session;
 import io.crossbar.autobahn.wamp.interfaces.ITransport;
 import io.crossbar.autobahn.wamp.interfaces.ITransportHandler;
 import io.crossbar.autobahn.wamp.types.CallResult;

--- a/demo-gallery/src/main/java/io/crossbar/autobahn/demogallery/MainActivity.java
+++ b/demo-gallery/src/main/java/io/crossbar/autobahn/demogallery/MainActivity.java
@@ -31,13 +31,15 @@ import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.view.View;
 
+import io.crossbar.autobahn.wamp.Playground;
+
 public class MainActivity extends AppCompatActivity implements View.OnClickListener {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
-        io.crossbar.autobahn.demogallery.Playground playground = new io.crossbar.autobahn.demogallery.Playground();
+        Playground playground = new Playground();
         playground.showTransportAttachment();
     }
 


### PR DESCRIPTION
To build the project with Android support we need the Android SDK, since the new implementation does not rely on Android we can create a jar without the Android bits.