### PR TITLE
Allow dynamic builds

### DIFF
--- a/autobahn/build.gradle
+++ b/autobahn/build.gradle
@@ -1,7 +1,17 @@
+apply plugin: getPlugin()
+
 String PLUGIN_ANDROID = "com.android.library"
 String PLUGIN_JAVA = "java"
 
-apply plugin: PLUGIN_ANDROID
+String getPlugin() {
+    String buildPlugin = project.properties.get("buildPlatform")
+    switch (buildPlugin) {
+        case "java":
+            return "java"
+        default:
+            return "com.android.library"
+    }
+}
 
 if (plugins.hasPlugin(PLUGIN_ANDROID)) {
     android {

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,9 @@
 buildscript {
     repositories {
         jcenter()
+        maven {
+            url "https://maven.google.com"
+        }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.0-alpha3'


### PR DESCRIPTION
Enables dynamic build to be used for Docker builds

example:
`gradle :autobahn:jar -P buildPlatform=java`