### PR TITLE
Add Netty demo target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,3 +5,10 @@ build_netty:
 	time docker build \
 		-t crossbario/autobahn-java:netty \
 		-f ./docker/Dockerfile.netty .
+
+demo_wamp_netty:
+	docker run -v $(shell pwd):/workspace \
+		-it --rm crossbario/autobahn-java:netty /bin/bash -c \
+                "gradle installDist -PbuildPlatform=netty && \
+		demo-gallery/build/install/demo-gallery/bin/demo-gallery \
+                ws://$(shell docker inspect --format '{{ .NetworkSettings.IPAddress }}' crossbar):8080/ws"


### PR DESCRIPTION
The demo client, if not provided any websocket URI as parameter by default tries to connect to localhost:8080 but due to some reason `docker --link` did not seem to have any effect for me, so as a stop gap, I am querying the IP address of the crossbar container and providing it to the demo client.

-- This branch, only joins a realm1, nothing else right now, but it will grow from here.