### PR TITLE
[Do not merge] Attempt dynamic return type for Session.call()

### DIFF
--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/NettyTransport.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/NettyTransport.java
@@ -151,9 +151,14 @@ public class NettyTransport implements ITransport {
     public void send(IMessage message) {
         System.out.println("  >>> TX : " + message);
 
-        byte[] data = mSerializer.serialize(message.marshal());
-        WebSocketFrame frame = new BinaryWebSocketFrame(toByteBuf(data));
-        mChannel.writeAndFlush(frame);
+        // #FIXME: ugly, signature should throw exception.
+        try {
+            byte[] data = mSerializer.serialize(message.marshal());
+            WebSocketFrame frame = new BinaryWebSocketFrame(toByteBuf(data));
+            mChannel.writeAndFlush(frame);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
     }
 
     @Override

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/NettyWebSocketClientHandler.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/NettyWebSocketClientHandler.java
@@ -92,7 +92,7 @@ public class NettyWebSocketClientHandler extends SimpleChannelInboundHandler<Obj
             byte[] output = new byte[binaryWebSocketFrame.content().readableBytes()];
             binaryWebSocketFrame.content().readBytes(output);
             List<Object> message = mSerializer.unserialize(output, true);
-            mTransportHandler.onMessage(getMessageObject(message));
+            mTransportHandler.onMessage(getMessageObject(message), mSerializer);
         } else if (frame instanceof CloseWebSocketFrame) {
             ch.close();
         }

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/NettyWebSocketClientHandler.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/NettyWebSocketClientHandler.java
@@ -75,7 +75,7 @@ public class NettyWebSocketClientHandler extends SimpleChannelInboundHandler<Obj
         if (!mHandshaker.isHandshakeComplete()) {
             mHandshaker.finishHandshake(ch, (FullHttpResponse) msg);
             mHandshakeFuture.setSuccess();
-            mTransportHandler.onConnect(mTransport);
+            mTransportHandler.onConnect(mTransport, mSerializer);
             return;
         }
 
@@ -92,7 +92,7 @@ public class NettyWebSocketClientHandler extends SimpleChannelInboundHandler<Obj
             byte[] output = new byte[binaryWebSocketFrame.content().readableBytes()];
             binaryWebSocketFrame.content().readBytes(output);
             List<Object> message = mSerializer.unserialize(output, true);
-            mTransportHandler.onMessage(getMessageObject(message), mSerializer);
+            mTransportHandler.onMessage(getMessageObject(message));
         } else if (frame instanceof CloseWebSocketFrame) {
             ch.close();
         }

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/NettyWebSocketClientHandler.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/NettyWebSocketClientHandler.java
@@ -11,9 +11,6 @@
 
 package io.crossbar.autobahn.wamp;
 
-import java.util.List;
-
-import io.crossbar.autobahn.wamp.interfaces.IMessage;
 import io.crossbar.autobahn.wamp.interfaces.ISerializer;
 import io.crossbar.autobahn.wamp.interfaces.ITransport;
 import io.crossbar.autobahn.wamp.interfaces.ITransportHandler;
@@ -28,8 +25,6 @@ import io.netty.handler.codec.http.websocketx.CloseWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.WebSocketClientHandshaker;
 import io.netty.handler.codec.http.websocketx.WebSocketFrame;
 import io.netty.util.CharsetUtil;
-
-import static io.crossbar.autobahn.wamp.messages.MessageMap.MESSAGE_TYPE_MAP;
 
 public class NettyWebSocketClientHandler extends SimpleChannelInboundHandler<Object> {
 
@@ -91,17 +86,10 @@ public class NettyWebSocketClientHandler extends SimpleChannelInboundHandler<Obj
             BinaryWebSocketFrame binaryWebSocketFrame = (BinaryWebSocketFrame) frame;
             byte[] output = new byte[binaryWebSocketFrame.content().readableBytes()];
             binaryWebSocketFrame.content().readBytes(output);
-            List<Object> message = mSerializer.unserialize(output, true);
-            mTransportHandler.onMessage(getMessageObject(message));
+            mTransportHandler.onMessage(output);
         } else if (frame instanceof CloseWebSocketFrame) {
             ch.close();
         }
-    }
-
-    private IMessage getMessageObject(List<Object> rawMessage) throws Exception {
-        int messageType = (int) rawMessage.get(0);
-        Class<? extends IMessage> messageKlass = MESSAGE_TYPE_MAP.get(messageType);
-        return (IMessage) messageKlass.getMethod("parse", List.class).invoke(null, rawMessage);
     }
 
     @Override

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/Session.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/Session.java
@@ -198,15 +198,18 @@ public class Session implements ISession, ITransportHandler {
                 if (request != null) {
                     mCallRequests.remove(requestID);
                     if (request.resultType == CallResult.class) {
-                        List<Object> incoming = mSerializer.unserialize(rawMessage, true);
-                        Result msg = Result.parse(incoming);
+                        Result msg = (Result) message;
                         request.onReply.complete(new CallResult(msg.args, msg.kwargs));
                     } else {
                         TypeReference<Map<String, Object>> detailsType = new TypeReference<Map<String, Object>>() {};
                         @SuppressWarnings("Variable unused for now.")
                         Map<String, Object> details = parser.readValueAs(detailsType);
 
-                        // We want to slice out the bytes from the raw message
+                        // We want to slice out the bytes from the raw message.
+                        // There might be a better way to do this, need to investigate.
+                        // JsonParser.readValueAs does not take JavaType as a parameter,
+                        // due to that we to unserialize using the ObjectMapper because
+                        // JavaType is the only class that support dynamic type definition.
                         int argsOffsetStart = (int) parser.getCurrentLocation().getByteOffset();
                         while (parser.nextToken() != JsonToken.END_ARRAY) {}
                         int argsOffsetEnd = (int) parser.getCurrentLocation().getByteOffset();

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/Session.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/Session.java
@@ -22,6 +22,7 @@ import java.util.concurrent.ForkJoinPool;
 import io.crossbar.autobahn.wamp.exceptions.ApplicationError;
 import io.crossbar.autobahn.wamp.exceptions.ProtocolError;
 import io.crossbar.autobahn.wamp.interfaces.IMessage;
+import io.crossbar.autobahn.wamp.interfaces.ISerializer;
 import io.crossbar.autobahn.wamp.interfaces.ISession;
 import io.crossbar.autobahn.wamp.interfaces.ITransport;
 import io.crossbar.autobahn.wamp.interfaces.ITransportHandler;
@@ -138,7 +139,7 @@ public class Session implements ISession, ITransportHandler {
     }
 
     @Override
-    public void onMessage(IMessage message) {
+    public void onMessage(IMessage message, ISerializer serializer) {
         System.out.println("  <<< RX : " + message);
 
         if (mSessionID == 0) {
@@ -173,7 +174,8 @@ public class Session implements ISession, ITransportHandler {
                     if (request.resultType == null) {
                         request.onReply.complete(new CallResult(msg.args, msg.kwargs));
                     } else {
-                        // XXXXX - Use serializer here ?
+                        // XXXXX - Here is a problem:
+                        // the Result object here is already serialized of the format.
                     }
                 } else {
                     throw new ProtocolError(String.format(

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/Session.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/Session.java
@@ -155,19 +155,18 @@ public class Session implements ISession, ITransportHandler {
 
     @Override
     public void onMessage(byte[] rawMessage) throws Exception {
-        int messageTypeID;
-        IMessage message;
         // This JsonNode _should_ be passed on to each message class so that
         // all the casting inside each Message class can be removed.
         // Currently we pass List<Object>.
         JsonNode msgNode = mSerializer.getMapper().readValue(rawMessage, JsonNode.class);
-        if (msgNode.isArray() && (msgNode.get(0).isInt() || msgNode.get(0).isLong())) {
-            List<Object> incoming = mSerializer.unserialize(rawMessage, true);
-            messageTypeID = msgNode.get(0).asInt();
-            message = getMessageObject(messageTypeID, incoming);
-        } else {
+
+        if (!msgNode.isArray() || !(msgNode.get(0).isInt() || msgNode.get(0).isLong())) {
             throw new ProtocolError("Invalid message received");
         }
+
+        List<Object> incoming = mSerializer.unserialize(rawMessage, true);
+        int messageTypeID = msgNode.get(0).asInt();
+        IMessage message = getMessageObject(messageTypeID, incoming);
 
         if (mSessionID == 0) {
             if (messageTypeID == Welcome.MESSAGE_TYPE) {

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/Session.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/Session.java
@@ -206,7 +206,8 @@ public class Session implements ISession, ITransportHandler {
 
                         // FIXME: This is bad, v.bad.
                         // The problem is, we don't have a way to know if the request.resultType
-                        // is a collection/list or just an object.
+                        // is a collection/list or just an object. So we are first trying to
+                        // map it to a list and fallback to a single object mapping.
                         try {
                             request.onReply.complete(reader.readValue(msgNode.get(3)));
                         } catch (JsonMappingException e) {

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/Session.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/Session.java
@@ -174,8 +174,11 @@ public class Session implements ISession, ITransportHandler {
                     if (request.resultType == null) {
                         request.onReply.complete(new CallResult(msg.args, msg.kwargs));
                     } else {
-                        // XXXXX - Here is a problem:
-                        // the Result object here is already serialized of the format.
+                        // Basically convert the List<Object> that came Transport
+                        // to List<request.resultType>
+                        request.onReply.complete(
+                                serializer.unserialize(serializer.serialize(msg.args),
+                                        true, request.resultType));
                     }
                 } else {
                     throw new ProtocolError(String.format(

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/Session.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/Session.java
@@ -174,7 +174,7 @@ public class Session implements ISession, ITransportHandler {
                     if (request.resultType == null) {
                         request.onReply.complete(new CallResult(msg.args, msg.kwargs));
                     } else {
-                        // Basically convert the List<Object> that came Transport
+                        // Basically convert the List<Object> that came from Transport
                         // to List<request.resultType>
                         request.onReply.complete(
                                 serializer.unserialize(serializer.serialize(msg.args),

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/interfaces/ISerializer.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/interfaces/ISerializer.java
@@ -19,6 +19,6 @@ public interface ISerializer {
 
     List<Object> unserialize(byte[] payload, boolean isBinary);
 
-    <T> T unserialize(byte[] payload, boolean isBinary, Class<T> Klass);
+    <T> T unserialize(byte[] payload, boolean isBinary, Class<?> collectionClass, Class<?>... subclasses);
 
 }

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/interfaces/ISerializer.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/interfaces/ISerializer.java
@@ -11,14 +11,19 @@
 
 package io.crossbar.autobahn.wamp.interfaces;
 
+import com.fasterxml.jackson.core.JsonParser;
+
 import java.util.List;
 
 public interface ISerializer {
 
-    byte[] serialize(List<Object> message);
+    byte[] serialize(List<Object> message) throws Exception;
 
-    List<Object> unserialize(byte[] payload, boolean isBinary);
+    List<Object> unserialize(byte[] payload, boolean isBinary) throws Exception;
 
-    <T> T unserialize(byte[] payload, boolean isBinary, Class<?> collectionClass, Class<?>... subclasses);
+    <T> T unserialize(byte[] payload, boolean isBinary, Class<?> collectionClass, Class<?>... subclasses)
+            throws Exception;
+
+    JsonParser getParser(byte[] rawMessage) throws Exception;
 
 }

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/interfaces/ISerializer.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/interfaces/ISerializer.java
@@ -19,4 +19,6 @@ public interface ISerializer {
 
     List<Object> unserialize(byte[] payload, boolean isBinary);
 
+    <T> T unserialize(byte[] payload, boolean isBinary, Class<T> Klass);
+
 }

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/interfaces/ISerializer.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/interfaces/ISerializer.java
@@ -12,6 +12,7 @@
 package io.crossbar.autobahn.wamp.interfaces;
 
 import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.util.List;
 
@@ -25,5 +26,7 @@ public interface ISerializer {
             throws Exception;
 
     JsonParser getParser(byte[] rawMessage) throws Exception;
+
+    ObjectMapper getMapper();
 
 }

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/interfaces/ISerializer.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/interfaces/ISerializer.java
@@ -11,7 +11,6 @@
 
 package io.crossbar.autobahn.wamp.interfaces;
 
-import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.util.List;
@@ -21,11 +20,6 @@ public interface ISerializer {
     byte[] serialize(List<Object> message) throws Exception;
 
     List<Object> unserialize(byte[] payload, boolean isBinary) throws Exception;
-
-    <T> T unserialize(byte[] payload, boolean isBinary, Class<?> collectionClass, Class<?>... subclasses)
-            throws Exception;
-
-    JsonParser getParser(byte[] rawMessage) throws Exception;
 
     ObjectMapper getMapper();
 

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/interfaces/ISession.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/interfaces/ISession.java
@@ -48,6 +48,11 @@ public interface ISession {
                                        CallOptions options);
 
     <T> CompletableFuture<T> call(String procedure,
+                                  TypeReference<T> resultType,
+                                  CallOptions options,
+                                  Object... args);
+
+    <T> CompletableFuture<T> call(String procedure,
                                   List<Object> args,
                                   Map<String, Object> kwargs,
                                   TypeReference<T> resultType,

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/interfaces/ISession.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/interfaces/ISession.java
@@ -45,6 +45,12 @@ public interface ISession {
                                        Map<String, Object> kwargs,
                                        CallOptions options);
 
+    <T> CompletableFuture<T> call(String procedure,
+                                  List<Object> args,
+                                  Map<String, Object> kwargs,
+                                  Class<T> resultType,
+                                  CallOptions options);
+
     CompletableFuture<SessionDetails> join(String realm, List<String> authMethods);
 
     void leave(String reason, String message);

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/interfaces/ISession.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/interfaces/ISession.java
@@ -45,11 +45,11 @@ public interface ISession {
                                        Map<String, Object> kwargs,
                                        CallOptions options);
 
-    <T> CompletableFuture<T> call(String procedure,
-                                  List<Object> args,
-                                  Map<String, Object> kwargs,
-                                  Class<T> resultType,
-                                  CallOptions options);
+    <T> CompletableFuture<List<T>> call(String procedure,
+                                        List<Object> args,
+                                        Map<String, Object> kwargs,
+                                        Class<T> resultType,
+                                        CallOptions options);
 
     CompletableFuture<SessionDetails> join(String realm, List<String> authMethods);
 

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/interfaces/ISession.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/interfaces/ISession.java
@@ -11,6 +11,8 @@
 
 package io.crossbar.autobahn.wamp.interfaces;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -45,11 +47,11 @@ public interface ISession {
                                        Map<String, Object> kwargs,
                                        CallOptions options);
 
-    <T> CompletableFuture<List<T>> call(String procedure,
-                                        List<Object> args,
-                                        Map<String, Object> kwargs,
-                                        Class<T> resultType,
-                                        CallOptions options);
+    <T> CompletableFuture<T> call(String procedure,
+                                  List<Object> args,
+                                  Map<String, Object> kwargs,
+                                  TypeReference<T> resultType,
+                                  CallOptions options);
 
     CompletableFuture<SessionDetails> join(String realm, List<String> authMethods);
 

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/interfaces/ITransportHandler.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/interfaces/ITransportHandler.java
@@ -15,9 +15,9 @@ public interface ITransportHandler {
 
     // all of the following methods need to be implemented in Session
 
-    void onConnect(ITransport transport);
+    void onConnect(ITransport transport, ISerializer serializer);
 
-    void onMessage(IMessage message, ISerializer serializer);
+    void onMessage(IMessage message);
 
     void onDisconnect(boolean wasClean);
 

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/interfaces/ITransportHandler.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/interfaces/ITransportHandler.java
@@ -17,7 +17,7 @@ public interface ITransportHandler {
 
     void onConnect(ITransport transport);
 
-    void onMessage(IMessage message);
+    void onMessage(IMessage message, ISerializer serializer);
 
     void onDisconnect(boolean wasClean);
 

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/interfaces/ITransportHandler.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/interfaces/ITransportHandler.java
@@ -17,7 +17,7 @@ public interface ITransportHandler {
 
     void onConnect(ITransport transport, ISerializer serializer);
 
-    void onMessage(IMessage message);
+    void onMessage(byte[] rawMessage);
 
     void onDisconnect(boolean wasClean);
 

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/interfaces/ITransportHandler.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/interfaces/ITransportHandler.java
@@ -17,7 +17,7 @@ public interface ITransportHandler {
 
     void onConnect(ITransport transport, ISerializer serializer);
 
-    void onMessage(byte[] rawMessage);
+    void onMessage(byte[] rawMessage) throws Exception;
 
     void onDisconnect(boolean wasClean);
 

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/requests/CallRequest.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/requests/CallRequest.java
@@ -21,14 +21,6 @@ public class CallRequest extends Request {
     public final CompletableFuture onReply;
     public final Class resultType;
 
-    public <T> CallRequest(long request, String procedure, CompletableFuture<T> onReply, CallOptions options) {
-        super(request);
-        this.procedure = procedure;
-        this.options = options;
-        this.onReply = onReply;
-        this.resultType = null;
-    }
-
     public CallRequest(long request, String procedure, CompletableFuture onReply, CallOptions options,
                        Class resultType) {
         super(request);

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/requests/CallRequest.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/requests/CallRequest.java
@@ -14,18 +14,27 @@ package io.crossbar.autobahn.wamp.requests;
 import java.util.concurrent.CompletableFuture;
 
 import io.crossbar.autobahn.wamp.types.CallOptions;
-import io.crossbar.autobahn.wamp.types.CallResult;
 
 public class CallRequest extends Request {
     public final String procedure;
     public final CallOptions options;
-    public final CompletableFuture<CallResult> onReply;
+    public final CompletableFuture onReply;
+    public final Class resultType;
 
-    public CallRequest(long request, String procedure, CompletableFuture<CallResult> onReply,
-                       CallOptions options) {
+    public <T> CallRequest(long request, String procedure, CompletableFuture<T> onReply, CallOptions options) {
         super(request);
         this.procedure = procedure;
         this.options = options;
         this.onReply = onReply;
+        this.resultType = null;
+    }
+
+    public CallRequest(long request, String procedure, CompletableFuture onReply, CallOptions options,
+                       Class resultType) {
+        super(request);
+        this.procedure = procedure;
+        this.options = options;
+        this.onReply = onReply;
+        this.resultType = resultType;
     }
 }

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/requests/CallRequest.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/requests/CallRequest.java
@@ -11,6 +11,8 @@
 
 package io.crossbar.autobahn.wamp.requests;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+
 import java.util.concurrent.CompletableFuture;
 
 import io.crossbar.autobahn.wamp.types.CallOptions;
@@ -19,10 +21,10 @@ public class CallRequest extends Request {
     public final String procedure;
     public final CallOptions options;
     public final CompletableFuture onReply;
-    public final Class resultType;
+    public final TypeReference resultType;
 
     public CallRequest(long request, String procedure, CompletableFuture onReply, CallOptions options,
-                       Class resultType) {
+                       TypeReference resultType) {
         super(request);
         this.procedure = procedure;
         this.options = options;

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/types/CBORSerializer.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/types/CBORSerializer.java
@@ -11,12 +11,11 @@
 
 package io.crossbar.autobahn.wamp.types;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.cbor.CBORFactory;
 
-import java.io.IOException;
 import java.util.List;
 
 import io.crossbar.autobahn.wamp.interfaces.ISerializer;
@@ -24,39 +23,33 @@ import io.crossbar.autobahn.wamp.interfaces.ISerializer;
 public class CBORSerializer implements ISerializer {
 
     private ObjectMapper mMapper;
+    private CBORFactory mFactory;
 
     public CBORSerializer() {
         mMapper = new ObjectMapper(new CBORFactory());
+        mFactory = new CBORFactory();
+        mFactory.setCodec(mMapper);
     }
 
     @Override
-    public byte[] serialize(List<Object> message) {
-        try {
-            return mMapper.writeValueAsBytes(message);
-        } catch (JsonProcessingException e) {
-            e.printStackTrace();
-            return null;
-        }
+    public byte[] serialize(List<Object> message) throws Exception {
+        return mMapper.writeValueAsBytes(message);
     }
 
     @Override
-    public List<Object> unserialize(byte[] payload, boolean isBinary) {
-        try {
-            return mMapper.readValue(payload, List.class);
-        } catch (IOException e) {
-            e.printStackTrace();
-            return null;
-        }
+    public List<Object> unserialize(byte[] payload, boolean isBinary) throws Exception {
+        return mMapper.readValue(payload, List.class);
     }
 
     @Override
-    public <T> T unserialize(byte[] payload, boolean isBinary, Class<?> collectionClass, Class<?>... subclasses) {
-        try {
-            JavaType type = mMapper.getTypeFactory().constructParametricType(collectionClass, subclasses);
-            return mMapper.readValue(payload, type);
-        } catch (IOException e) {
-            e.printStackTrace();
-            return null;
-        }
+    public <T> T unserialize(byte[] payload, boolean isBinary, Class<?> collectionClass, Class<?>... subclasses)
+            throws Exception {
+        JavaType type = mMapper.getTypeFactory().constructParametricType(collectionClass, subclasses);
+        return mMapper.readValue(payload, type);
+    }
+
+    @Override
+    public JsonParser getParser(byte[] rawMessage) throws Exception {
+        return mFactory.createParser(rawMessage);
     }
 }

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/types/CBORSerializer.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/types/CBORSerializer.java
@@ -21,7 +21,7 @@ import io.crossbar.autobahn.wamp.interfaces.ISerializer;
 
 public class CBORSerializer implements ISerializer {
 
-    private ObjectMapper mMapper;
+    private final ObjectMapper mMapper;
 
     public CBORSerializer() {
         mMapper = new ObjectMapper(new CBORFactory());

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/types/CBORSerializer.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/types/CBORSerializer.java
@@ -47,4 +47,14 @@ public class CBORSerializer implements ISerializer {
             return null;
         }
     }
+
+    @Override
+    public <T> T unserialize(byte[] payload, boolean isBinary, Class<T> Klass) {
+        try {
+            return mMapper.readValue(payload, Klass);
+        } catch (IOException e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
 }

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/types/CBORSerializer.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/types/CBORSerializer.java
@@ -11,8 +11,7 @@
 
 package io.crossbar.autobahn.wamp.types;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.cbor.CBORFactory;
 
@@ -23,12 +22,9 @@ import io.crossbar.autobahn.wamp.interfaces.ISerializer;
 public class CBORSerializer implements ISerializer {
 
     private ObjectMapper mMapper;
-    private CBORFactory mFactory;
 
     public CBORSerializer() {
         mMapper = new ObjectMapper(new CBORFactory());
-        mFactory = new CBORFactory();
-        mFactory.setCodec(mMapper);
     }
 
     @Override
@@ -38,19 +34,7 @@ public class CBORSerializer implements ISerializer {
 
     @Override
     public List<Object> unserialize(byte[] payload, boolean isBinary) throws Exception {
-        return mMapper.readValue(payload, List.class);
-    }
-
-    @Override
-    public <T> T unserialize(byte[] payload, boolean isBinary, Class<?> collectionClass, Class<?>... subclasses)
-            throws Exception {
-        JavaType type = mMapper.getTypeFactory().constructParametricType(collectionClass, subclasses);
-        return mMapper.readValue(payload, type);
-    }
-
-    @Override
-    public JsonParser getParser(byte[] rawMessage) throws Exception {
-        return mFactory.createParser(rawMessage);
+        return mMapper.readValue(payload, new TypeReference<List<Object>>() {});
     }
 
     @Override

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/types/CBORSerializer.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/types/CBORSerializer.java
@@ -12,6 +12,7 @@
 package io.crossbar.autobahn.wamp.types;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.cbor.CBORFactory;
 
@@ -49,9 +50,10 @@ public class CBORSerializer implements ISerializer {
     }
 
     @Override
-    public <T> T unserialize(byte[] payload, boolean isBinary, Class<T> Klass) {
+    public <T> T unserialize(byte[] payload, boolean isBinary, Class<?> collectionClass, Class<?>... subclasses) {
         try {
-            return mMapper.readValue(payload, Klass);
+            JavaType type = mMapper.getTypeFactory().constructParametricType(collectionClass, subclasses);
+            return mMapper.readValue(payload, type);
         } catch (IOException e) {
             e.printStackTrace();
             return null;

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/types/CBORSerializer.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/types/CBORSerializer.java
@@ -52,4 +52,9 @@ public class CBORSerializer implements ISerializer {
     public JsonParser getParser(byte[] rawMessage) throws Exception {
         return mFactory.createParser(rawMessage);
     }
+
+    @Override
+    public ObjectMapper getMapper() {
+        return mMapper;
+    }
 }

--- a/demo-gallery/src/main/java/io/crossbar/autobahn/demogallery/netty/Service.java
+++ b/demo-gallery/src/main/java/io/crossbar/autobahn/demogallery/netty/Service.java
@@ -11,6 +11,8 @@
 
 package io.crossbar.autobahn.demogallery.netty;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -206,8 +208,9 @@ public class Service {
     }
 
     private void test() {
+        TypeReference<List<RandomClass>> resultType = new TypeReference<List<RandomClass>>() {};
         CompletableFuture<List<RandomClass>> r = mSession.call(
-                "com.example.pojo", null, null, RandomClass.class, null);
+                "com.example.pojo", null, null, resultType, null);
         r.thenAcceptAsync(randomClasses -> randomClasses.forEach(randomClass -> {
             System.out.println(randomClass.firstName);
             System.out.println(randomClass.lastName);

--- a/demo-gallery/src/main/java/io/crossbar/autobahn/demogallery/netty/Service.java
+++ b/demo-gallery/src/main/java/io/crossbar/autobahn/demogallery/netty/Service.java
@@ -134,6 +134,8 @@ public class Service {
         args.add(2);
         args.add(3);
 
+        test();
+
         ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
         executorService.scheduleAtFixedRate(() -> {
 

--- a/demo-gallery/src/main/java/io/crossbar/autobahn/demogallery/netty/Service.java
+++ b/demo-gallery/src/main/java/io/crossbar/autobahn/demogallery/netty/Service.java
@@ -204,20 +204,30 @@ public class Service {
     }
 
     private void test() {
-        CompletableFuture<RandomClass> out = mSession.call("ssasa", null, null, RandomClass.class, null);
-        out.thenAcceptAsync(randomClass -> {
+        CompletableFuture<List<RandomClass>> r = mSession.call(
+                "com.example.pojo", null, null, RandomClass.class, null);
+        r.thenAcceptAsync(randomClasses -> randomClasses.forEach(randomClass -> {
             System.out.println(randomClass.firstName);
-            System.out.println(randomClass.fatherName);
+            System.out.println(randomClass.lastName);
+        }), mExecutor);
+        r.exceptionally(throwable -> {
+            throwable.printStackTrace();
+            return null;
         });
     }
 
-    private class RandomClass {
-        int firstName;
-        int fatherName;
+    // XXXX - For demonstration purpose only, to be removed.
+    static class RandomClass {
+        public String firstName;
+        public String lastName;
 
-        public RandomClass(int firstName, int fatherName) {
+        public RandomClass() {
+
+        }
+
+        public RandomClass(String firstName, String lastName) {
             this.firstName = firstName;
-            this.fatherName = fatherName;
+            this.lastName = lastName;
         }
     }
 }

--- a/demo-gallery/src/main/java/io/crossbar/autobahn/demogallery/netty/Service.java
+++ b/demo-gallery/src/main/java/io/crossbar/autobahn/demogallery/netty/Service.java
@@ -202,4 +202,22 @@ public class Service {
         System.out.println("received counter: " + args.get(0));
         return null;
     }
+
+    private void test() {
+        CompletableFuture<RandomClass> out = mSession.call("ssasa", null, null, RandomClass.class, null);
+        out.thenAcceptAsync(randomClass -> {
+            System.out.println(randomClass.firstName);
+            System.out.println(randomClass.fatherName);
+        });
+    }
+
+    private class RandomClass {
+        int firstName;
+        int fatherName;
+
+        public RandomClass(int firstName, int fatherName) {
+            this.firstName = firstName;
+            this.fatherName = fatherName;
+        }
+    }
 }


### PR DESCRIPTION
- This PR currently is only for feedback
- The idea here is to show how the implementation could potentially look like.

The main issue right now is that because Transport and Session are independent from each other, we do not have access to the serializer in the Session class to actually construct the object based on resultType. One idea is to pass in the serializer as a parameter to onMessage(), so that the session class can access the serializer.

If we want to put all the object mapping logic within the transport, that may actually be a challenge because the transport currently does not have access to all *requests object maps that we have in Session class.

Thoughts ?