### PR TITLE
Make message validation code non-repetitive

### DIFF
--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Abort.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Abort.java
@@ -16,8 +16,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import io.crossbar.autobahn.wamp.exceptions.ProtocolError;
 import io.crossbar.autobahn.wamp.interfaces.IMessage;
+import io.crossbar.autobahn.wamp.utils.MessageUtil;
 
 public class Abort implements IMessage {
 
@@ -32,13 +32,7 @@ public class Abort implements IMessage {
     }
 
     public static Abort parse(List<Object> wmsg) {
-        if (wmsg.size() == 0 || !(wmsg.get(0) instanceof Integer) || (int) wmsg.get(0) != MESSAGE_TYPE) {
-            throw new IllegalArgumentException("Invalid message.");
-        }
-
-        if (wmsg.size() != 3) {
-            throw new ProtocolError(String.format("invalid message length %s for ABORT", wmsg.size()));
-        }
+        MessageUtil.validateMessage(wmsg, MESSAGE_TYPE, "ABORT", 3);
 
         Map<String, Object> details = (Map<String, Object>) wmsg.get(1);
         String message = null;

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Authenticate.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Authenticate.java
@@ -15,8 +15,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import io.crossbar.autobahn.wamp.exceptions.ProtocolError;
 import io.crossbar.autobahn.wamp.interfaces.IMessage;
+import io.crossbar.autobahn.wamp.utils.MessageUtil;
 
 public class Authenticate implements IMessage {
 
@@ -31,13 +31,7 @@ public class Authenticate implements IMessage {
     }
 
     public static Authenticate parse(List<Object> wmsg) {
-        if (wmsg.size() == 0 || !(wmsg.get(0) instanceof Integer) || (int) wmsg.get(0) != MESSAGE_TYPE) {
-            throw new IllegalArgumentException("Invalid message.");
-        }
-
-        if (wmsg.size() != 3) {
-            throw new ProtocolError(String.format("invalid message length %s for CHALLENGE", wmsg.size()));
-        }
+        MessageUtil.validateMessage(wmsg, MESSAGE_TYPE, "AUTHENTICATE", 3);
         return new Authenticate((String) wmsg.get(1), (Map<String, Object>) wmsg.get(2));
     }
 

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Call.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Call.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import io.crossbar.autobahn.wamp.exceptions.ProtocolError;
 import io.crossbar.autobahn.wamp.interfaces.IMessage;
 import io.crossbar.autobahn.wamp.utils.Cast;
+import io.crossbar.autobahn.wamp.utils.MessageUtil;
 
 public class Call implements IMessage {
 
@@ -45,13 +46,7 @@ public class Call implements IMessage {
     }
 
     public static Call parse(List<Object> wmsg) {
-        if (wmsg.size() == 0 || !(wmsg.get(0) instanceof Integer) || (int) wmsg.get(0) != MESSAGE_TYPE) {
-            throw new IllegalArgumentException("Invalid message.");
-        }
-
-        if (wmsg.size() != 4) {
-            throw new ProtocolError(String.format("invalid message length %s for CALL", wmsg.size()));
-        }
+        MessageUtil.validateMessage(wmsg, MESSAGE_TYPE, "CALL", 4);
 
         long request = Cast.castRequestID(wmsg.get(1));
         Map<String, Object> options = (Map<String, Object>) wmsg.get(2);

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Cancel.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Cancel.java
@@ -17,9 +17,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-import io.crossbar.autobahn.wamp.exceptions.ProtocolError;
 import io.crossbar.autobahn.wamp.interfaces.IMessage;
 import io.crossbar.autobahn.wamp.utils.Cast;
+import io.crossbar.autobahn.wamp.utils.MessageUtil;
 
 public class Cancel implements IMessage {
 
@@ -43,14 +43,7 @@ public class Cancel implements IMessage {
     }
 
     public static Cancel parse(List<Object> wmsg) {
-        if (wmsg.size() == 0 || !(wmsg.get(0) instanceof Integer) || (int) wmsg.get(0) != MESSAGE_TYPE) {
-            throw new IllegalArgumentException("Invalid message.");
-        }
-
-        if (wmsg.size() != 3) {
-            throw new ProtocolError(String.format("invalid message length %s for CANCEL", wmsg.size()));
-        }
-
+        MessageUtil.validateMessage(wmsg, MESSAGE_TYPE, "CANCEL", 3);
         long request = Cast.castRequestID(wmsg.get(1));
         Map<String, Object> options = (Map<String, Object>) wmsg.get(2);
         String mode = (String) options.getOrDefault("mode", null);

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Challenge.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Challenge.java
@@ -15,8 +15,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import io.crossbar.autobahn.wamp.exceptions.ProtocolError;
 import io.crossbar.autobahn.wamp.interfaces.IMessage;
+import io.crossbar.autobahn.wamp.utils.MessageUtil;
 
 public class Challenge implements IMessage {
 
@@ -31,13 +31,7 @@ public class Challenge implements IMessage {
     }
 
     public static Challenge parse(List<Object> wmsg) {
-        if (wmsg.size() == 0 || !(wmsg.get(0) instanceof Integer) || (int) wmsg.get(0) != MESSAGE_TYPE) {
-            throw new IllegalArgumentException("Invalid message.");
-        }
-
-        if (wmsg.size() != 3) {
-            throw new ProtocolError(String.format("invalid message length %s for CHALLENGE", wmsg.size()));
-        }
+        MessageUtil.validateMessage(wmsg, MESSAGE_TYPE, "CHALLENGE", 3);
         return new Challenge((String) wmsg.get(1), (Map<String, Object>) wmsg.get(2));
     }
 

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Error.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Error.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import io.crossbar.autobahn.wamp.exceptions.ProtocolError;
 import io.crossbar.autobahn.wamp.interfaces.IMessage;
 import io.crossbar.autobahn.wamp.utils.Cast;
+import io.crossbar.autobahn.wamp.utils.MessageUtil;
 
 public class Error implements IMessage {
 
@@ -39,13 +40,7 @@ public class Error implements IMessage {
     }
 
     public static Error parse(List<Object> wmsg) {
-        if (wmsg.size() == 0 || !(wmsg.get(0) instanceof Integer) || (int) wmsg.get(0) != MESSAGE_TYPE) {
-            throw new IllegalArgumentException("Invalid message.");
-        }
-
-        if (wmsg.size() < 5 || wmsg.size() > 7) {
-            throw new ProtocolError(String.format("invalid message length %s for ERROR", wmsg.size()));
-        }
+        MessageUtil.validateMessage(wmsg, MESSAGE_TYPE, "ERROR", 5, 7);
 
         int requestType = (int) wmsg.get(1);
         // FIXME: add validation here. see:

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Event.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Event.java
@@ -18,6 +18,7 @@ import java.util.Map;
 
 import io.crossbar.autobahn.wamp.exceptions.ProtocolError;
 import io.crossbar.autobahn.wamp.interfaces.IMessage;
+import io.crossbar.autobahn.wamp.utils.MessageUtil;
 
 public class Event implements IMessage {
 
@@ -36,14 +37,7 @@ public class Event implements IMessage {
     }
 
     public static Event parse(List<Object> wmsg) {
-        if (wmsg.size() == 0 || !(wmsg.get(0) instanceof Integer) || (int) wmsg.get(0) != MESSAGE_TYPE) {
-            throw new IllegalArgumentException("Invalid message.");
-        }
-
-        if (wmsg.size() < 3 || wmsg.size() > 6) {
-            throw new ProtocolError(String.format("invalid message length %s for EVENT", wmsg.size()));
-        }
-
+        MessageUtil.validateMessage(wmsg, MESSAGE_TYPE, "EVENT", 3, 6);
         long subscription = (long) wmsg.get(1);
         long publication = (long) wmsg.get(2);
         Map<String, Object> details = (Map<String, Object>) wmsg.get(3);

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Goodbye.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Goodbye.java
@@ -16,8 +16,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import io.crossbar.autobahn.wamp.exceptions.ProtocolError;
 import io.crossbar.autobahn.wamp.interfaces.IMessage;
+import io.crossbar.autobahn.wamp.utils.MessageUtil;
 
 public class Goodbye implements IMessage {
 
@@ -38,13 +38,7 @@ public class Goodbye implements IMessage {
     }
 
     public static Goodbye parse(List<Object> wmsg) {
-        if (wmsg.size() == 0 || !(wmsg.get(0) instanceof Integer) || (int) wmsg.get(0) != MESSAGE_TYPE) {
-            throw new IllegalArgumentException("Invalid message.");
-        }
-
-        if (wmsg.size() != 3) {
-            throw new ProtocolError(String.format("invalid message length %s for GOODBYE", wmsg.size()));
-        }
+        MessageUtil.validateMessage(wmsg, MESSAGE_TYPE, "GOODBYE", 3);
         Map<String, Object> details = (Map<String, Object>) wmsg.get(1);
         String message = null;
         if (details.containsKey("message")) {

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Hello.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Hello.java
@@ -16,8 +16,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import io.crossbar.autobahn.wamp.exceptions.ProtocolError;
 import io.crossbar.autobahn.wamp.interfaces.IMessage;
+import io.crossbar.autobahn.wamp.utils.MessageUtil;
 
 public class Hello implements IMessage {
 
@@ -38,13 +38,7 @@ public class Hello implements IMessage {
     }
 
     public static Hello parse(List<Object> wmsg) {
-        if (wmsg.size() == 0 || !(wmsg.get(0) instanceof Integer) || (int) wmsg.get(0) != MESSAGE_TYPE) {
-            throw new IllegalArgumentException("Invalid message.");
-        }
-
-        if (wmsg.size() != 3) {
-            throw new ProtocolError(String.format("invalid message length %s for HELLO", wmsg.size()));
-        }
+        MessageUtil.validateMessage(wmsg, MESSAGE_TYPE, "HELLO", 3);
 
         String realm = (String) wmsg.get(1);
 

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Interrupt.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Interrupt.java
@@ -20,6 +20,7 @@ import java.util.Objects;
 import io.crossbar.autobahn.wamp.exceptions.ProtocolError;
 import io.crossbar.autobahn.wamp.interfaces.IMessage;
 import io.crossbar.autobahn.wamp.utils.Cast;
+import io.crossbar.autobahn.wamp.utils.MessageUtil;
 
 public class Interrupt implements IMessage {
 
@@ -37,13 +38,7 @@ public class Interrupt implements IMessage {
     }
 
     public static Interrupt parse(List<Object> wmsg) {
-        if (wmsg.size() == 0 || !(wmsg.get(0) instanceof Integer) || (int) wmsg.get(0) != MESSAGE_TYPE) {
-            throw new IllegalArgumentException("Invalid message.");
-        }
-
-        if (wmsg.size() != 3) {
-            throw new ProtocolError(String.format("invalid message length %s for INTERRUPT", wmsg.size()));
-        }
+        MessageUtil.validateMessage(wmsg, MESSAGE_TYPE, "INTERRUPT", 3);
 
         long request = Cast.castRequestID(wmsg.get(1));
         Map<String, Object> options = (Map<String, Object>) wmsg.get(2);

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Invocation.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Invocation.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import io.crossbar.autobahn.wamp.exceptions.ProtocolError;
 import io.crossbar.autobahn.wamp.interfaces.IMessage;
 import io.crossbar.autobahn.wamp.utils.Cast;
+import io.crossbar.autobahn.wamp.utils.MessageUtil;
 
 public class Invocation implements IMessage {
 
@@ -37,13 +38,7 @@ public class Invocation implements IMessage {
     }
 
     public static Invocation parse(List<Object> wmsg) {
-        if (wmsg.size() == 0 || !(wmsg.get(0) instanceof Integer) || (int) wmsg.get(0) != MESSAGE_TYPE) {
-            throw new IllegalArgumentException("Invalid message.");
-        }
-
-        if (wmsg.size() < 3 || wmsg.size() > 6) {
-            throw new ProtocolError(String.format("invalid message length %s for INVOCATION", wmsg.size()));
-        }
+        MessageUtil.validateMessage(wmsg, MESSAGE_TYPE, "INNVOCATION", 3, 6);
 
         long request = Cast.castRequestID(wmsg.get(1));
         long registration = (long) wmsg.get(2);

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Publish.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Publish.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import io.crossbar.autobahn.wamp.exceptions.ProtocolError;
 import io.crossbar.autobahn.wamp.interfaces.IMessage;
 import io.crossbar.autobahn.wamp.utils.Cast;
+import io.crossbar.autobahn.wamp.utils.MessageUtil;
 
 public class Publish implements IMessage {
 
@@ -43,13 +44,7 @@ public class Publish implements IMessage {
     }
 
     public static Publish parse(List<Object> wmsg) {
-        if (wmsg.size() == 0 || !(wmsg.get(0) instanceof Integer) || (int) wmsg.get(0) != MESSAGE_TYPE) {
-            throw new IllegalArgumentException("Invalid message.");
-        }
-
-        if (wmsg.size() < 4 || wmsg.size() > 6) {
-            throw new ProtocolError(String.format("invalid message length %s for PUBLISH", wmsg.size()));
-        }
+        MessageUtil.validateMessage(wmsg, MESSAGE_TYPE, "PUBLISH", 4, 6);
 
         long request = Cast.castRequestID(wmsg.get(1));
         Map<String, Object> options = (Map<String, Object>) wmsg.get(2);

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Published.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Published.java
@@ -14,9 +14,9 @@ package io.crossbar.autobahn.wamp.messages;
 import java.util.ArrayList;
 import java.util.List;
 
-import io.crossbar.autobahn.wamp.exceptions.ProtocolError;
 import io.crossbar.autobahn.wamp.interfaces.IMessage;
 import io.crossbar.autobahn.wamp.utils.Cast;
+import io.crossbar.autobahn.wamp.utils.MessageUtil;
 
 public class Published implements IMessage {
 
@@ -31,14 +31,7 @@ public class Published implements IMessage {
     }
 
     public static Published parse(List<Object> wmsg) {
-        if (wmsg.size() == 0 || !(wmsg.get(0) instanceof Integer) || (int) wmsg.get(0) != MESSAGE_TYPE) {
-            throw new IllegalArgumentException("Invalid message.");
-        }
-
-        if (wmsg.size() != 3) {
-            throw new ProtocolError(String.format("invalid message length %s for PUBLISHED", wmsg.size()));
-        }
-
+        MessageUtil.validateMessage(wmsg, MESSAGE_TYPE, "PUBLISHED", 3);
         return new Published(Cast.castRequestID(wmsg.get(1)), (long) wmsg.get(2));
     }
 

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Register.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Register.java
@@ -20,6 +20,7 @@ import java.util.Objects;
 import io.crossbar.autobahn.wamp.exceptions.ProtocolError;
 import io.crossbar.autobahn.wamp.interfaces.IMessage;
 import io.crossbar.autobahn.wamp.utils.Cast;
+import io.crossbar.autobahn.wamp.utils.MessageUtil;
 
 public class Register implements IMessage {
 
@@ -67,13 +68,7 @@ public class Register implements IMessage {
     }
 
     public static Register parse(List<Object> wmsg) {
-        if (wmsg.size() == 0 || !(wmsg.get(0) instanceof Integer) || (int) wmsg.get(0) != MESSAGE_TYPE) {
-            throw new IllegalArgumentException("Invalid message.");
-        }
-
-        if (wmsg.size() != 4) {
-            throw new ProtocolError(String.format("invalid message length %s for REGISTER", wmsg.size()));
-        }
+        MessageUtil.validateMessage(wmsg, MESSAGE_TYPE, "REGISTER", 4);
 
         long request = Cast.castRequestID(wmsg.get(1));
         Map<String, Object> options = (Map<String, Object>) wmsg.get(2);

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Registered.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Registered.java
@@ -14,9 +14,9 @@ package io.crossbar.autobahn.wamp.messages;
 import java.util.ArrayList;
 import java.util.List;
 
-import io.crossbar.autobahn.wamp.exceptions.ProtocolError;
 import io.crossbar.autobahn.wamp.interfaces.IMessage;
 import io.crossbar.autobahn.wamp.utils.Cast;
+import io.crossbar.autobahn.wamp.utils.MessageUtil;
 
 public class Registered implements IMessage {
 
@@ -30,14 +30,7 @@ public class Registered implements IMessage {
     }
 
     public static Registered parse(List<Object> wmsg) {
-        if (wmsg.size() == 0 || !(wmsg.get(0) instanceof Integer) || (int) wmsg.get(0) != MESSAGE_TYPE) {
-            throw new IllegalArgumentException("Invalid message.");
-        }
-
-        if (wmsg.size() != 3) {
-            throw new ProtocolError(String.format("invalid message length %s for REGISTERED", wmsg.size()));
-        }
-
+        MessageUtil.validateMessage(wmsg, MESSAGE_TYPE, "REGISTERED", 3);
         return new Registered(Cast.castRequestID(wmsg.get(1)), (long) wmsg.get(2));
     }
 

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Result.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Result.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import io.crossbar.autobahn.wamp.exceptions.ProtocolError;
 import io.crossbar.autobahn.wamp.interfaces.IMessage;
 import io.crossbar.autobahn.wamp.utils.Cast;
+import io.crossbar.autobahn.wamp.utils.MessageUtil;
 
 public class Result implements IMessage {
     public static final int MESSAGE_TYPE = 50;
@@ -34,13 +35,7 @@ public class Result implements IMessage {
     }
 
     public static Result parse(List<Object> wmsg) {
-        if (wmsg.size() == 0 || !(wmsg.get(0) instanceof Integer) || (int) wmsg.get(0) != MESSAGE_TYPE) {
-            throw new IllegalArgumentException("Invalid message.");
-        }
-
-        if (wmsg.size() < 4 || wmsg.size() > 6) {
-            throw new ProtocolError(String.format("invalid message length %s for RESULT", wmsg.size()));
-        }
+        MessageUtil.validateMessage(wmsg, MESSAGE_TYPE, "RESULT", 4, 6);
 
         long request = Cast.castRequestID(wmsg.get(1));
         List<Object> args = null;

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Subscribe.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Subscribe.java
@@ -17,10 +17,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-import io.crossbar.autobahn.wamp.exceptions.ProtocolError;
 import io.crossbar.autobahn.wamp.interfaces.IMessage;
 import io.crossbar.autobahn.wamp.types.SubscribeOptions;
 import io.crossbar.autobahn.wamp.utils.Cast;
+import io.crossbar.autobahn.wamp.utils.MessageUtil;
 
 public class Subscribe implements IMessage {
 
@@ -54,13 +54,7 @@ public class Subscribe implements IMessage {
     }
 
     public static Subscribe parse(List<Object> wmsg) {
-        if (wmsg.size() == 0 || !(wmsg.get(0) instanceof Integer) || (int) wmsg.get(0) != MESSAGE_TYPE) {
-            throw new IllegalArgumentException("Invalid message.");
-        }
-
-        if (wmsg.size() != 4) {
-            throw new ProtocolError(String.format("invalid message length %s for SUBSCRIBE", wmsg.size()));
-        }
+        MessageUtil.validateMessage(wmsg, MESSAGE_TYPE, "SUBSCRIBE", 4);
 
         long request = Cast.castRequestID(wmsg.get(1));
         Map<String, Object> options = (Map<String, Object>) wmsg.get(2);

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Subscribed.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Subscribed.java
@@ -14,9 +14,9 @@ package io.crossbar.autobahn.wamp.messages;
 import java.util.ArrayList;
 import java.util.List;
 
-import io.crossbar.autobahn.wamp.exceptions.ProtocolError;
 import io.crossbar.autobahn.wamp.interfaces.IMessage;
 import io.crossbar.autobahn.wamp.utils.Cast;
+import io.crossbar.autobahn.wamp.utils.MessageUtil;
 
 public class Subscribed implements IMessage {
 
@@ -30,13 +30,7 @@ public class Subscribed implements IMessage {
     }
 
     public static Subscribed parse(List<Object> wmsg) {
-        if (wmsg.size() == 0 || !(wmsg.get(0) instanceof Integer) || (int) wmsg.get(0) != MESSAGE_TYPE) {
-            throw new IllegalArgumentException("Invalid message.");
-        }
-
-        if (wmsg.size() != 3) {
-            throw new ProtocolError(String.format("invalid message length %s for SUBSCRIBED", wmsg.size()));
-        }
+        MessageUtil.validateMessage(wmsg, MESSAGE_TYPE, "SUBSCRIBED", 3);
         return new Subscribed(Cast.castRequestID(wmsg.get(1)), (long) wmsg.get(2));
     }
 

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Unregister.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Unregister.java
@@ -14,9 +14,9 @@ package io.crossbar.autobahn.wamp.messages;
 import java.util.ArrayList;
 import java.util.List;
 
-import io.crossbar.autobahn.wamp.exceptions.ProtocolError;
 import io.crossbar.autobahn.wamp.interfaces.IMessage;
 import io.crossbar.autobahn.wamp.utils.Cast;
+import io.crossbar.autobahn.wamp.utils.MessageUtil;
 
 public class Unregister implements IMessage {
 
@@ -30,14 +30,7 @@ public class Unregister implements IMessage {
     }
 
     public static Unregister parse(List<Object> wmsg) {
-        if (wmsg.size() == 0 || !(wmsg.get(0) instanceof Integer) || (int) wmsg.get(0) != MESSAGE_TYPE) {
-            throw new IllegalArgumentException("Invalid message.");
-        }
-
-        if (wmsg.size() != 3) {
-            throw new ProtocolError(String.format("invalid message length %s for UNREGISTER", wmsg.size()));
-        }
-
+        MessageUtil.validateMessage(wmsg, MESSAGE_TYPE, "UNREGISTER", 3);
         return new Unregister(Cast.castRequestID(wmsg.get(1)), (long) wmsg.get(2));
     }
 

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Unregistered.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Unregistered.java
@@ -16,9 +16,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import io.crossbar.autobahn.wamp.exceptions.ProtocolError;
 import io.crossbar.autobahn.wamp.interfaces.IMessage;
 import io.crossbar.autobahn.wamp.utils.Cast;
+import io.crossbar.autobahn.wamp.utils.MessageUtil;
 
 public class Unregistered implements IMessage {
 
@@ -35,14 +35,8 @@ public class Unregistered implements IMessage {
         this.reason = reason;
     }
 
-    public static Unsubscribed parse(List<Object> wmsg) {
-        if (wmsg.size() == 0 || !(wmsg.get(0) instanceof Integer) || (int) wmsg.get(0) != MESSAGE_TYPE) {
-            throw new IllegalArgumentException("Invalid message.");
-        }
-
-        if (wmsg.size() < 2 || wmsg.size() > 3) {
-            throw new ProtocolError(String.format("invalid message length %s for UNSUBSCRIBED", wmsg.size()));
-        }
+    public static Unregistered parse(List<Object> wmsg) {
+        MessageUtil.validateMessage(wmsg, MESSAGE_TYPE, "UNREGISTERED", 2, 3);
 
         long registration = REGISTRATION_NULL;
         String reason = null;
@@ -52,7 +46,7 @@ public class Unregistered implements IMessage {
             reason = (String) details.getOrDefault("reason", reason);
         }
 
-        return new Unsubscribed(Cast.castRequestID(wmsg.get(1)), registration, reason);
+        return new Unregistered(Cast.castRequestID(wmsg.get(1)), registration, reason);
     }
 
     @Override

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Unsubscribe.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Unsubscribe.java
@@ -14,9 +14,9 @@ package io.crossbar.autobahn.wamp.messages;
 import java.util.ArrayList;
 import java.util.List;
 
-import io.crossbar.autobahn.wamp.exceptions.ProtocolError;
 import io.crossbar.autobahn.wamp.interfaces.IMessage;
 import io.crossbar.autobahn.wamp.utils.Cast;
+import io.crossbar.autobahn.wamp.utils.MessageUtil;
 
 public class Unsubscribe implements IMessage {
 
@@ -30,13 +30,7 @@ public class Unsubscribe implements IMessage {
     }
 
     public static Unsubscribe parse(List<Object> wmsg) {
-        if (wmsg.size() == 0 || !(wmsg.get(0) instanceof Integer) || (int) wmsg.get(0) != MESSAGE_TYPE) {
-            throw new IllegalArgumentException("Invalid message.");
-        }
-
-        if (wmsg.size() != 3) {
-            throw new ProtocolError(String.format("invalid message length %s for UNSUBSCRIBE", wmsg.size()));
-        }
+        MessageUtil.validateMessage(wmsg, MESSAGE_TYPE, "UNSUBSCRIBE", 3);
         return new Unsubscribe(Cast.castRequestID(wmsg.get(1)), (long) wmsg.get(2));
     }
 

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Unsubscribed.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Unsubscribed.java
@@ -16,9 +16,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import io.crossbar.autobahn.wamp.exceptions.ProtocolError;
 import io.crossbar.autobahn.wamp.interfaces.IMessage;
 import io.crossbar.autobahn.wamp.utils.Cast;
+import io.crossbar.autobahn.wamp.utils.MessageUtil;
 
 public class Unsubscribed implements IMessage {
 
@@ -36,13 +36,7 @@ public class Unsubscribed implements IMessage {
     }
 
     public static Unsubscribed parse(List<Object> wmsg) {
-        if (wmsg.size() == 0 || !(wmsg.get(0) instanceof Integer) || (int) wmsg.get(0) != MESSAGE_TYPE) {
-            throw new IllegalArgumentException("Invalid message.");
-        }
-
-        if (wmsg.size() < 2 || wmsg.size() > 3) {
-            throw new ProtocolError(String.format("invalid message length %s for UNSUBSCRIBED", wmsg.size()));
-        }
+        MessageUtil.validateMessage(wmsg, MESSAGE_TYPE, "UNSUBSCRIBED", 2, 3);
 
         long request = Cast.castRequestID(wmsg.get(1));
 

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Welcome.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Welcome.java
@@ -14,8 +14,8 @@ package io.crossbar.autobahn.wamp.messages;
 import java.util.List;
 import java.util.Map;
 
-import io.crossbar.autobahn.wamp.exceptions.ProtocolError;
 import io.crossbar.autobahn.wamp.interfaces.IMessage;
+import io.crossbar.autobahn.wamp.utils.MessageUtil;
 
 public class Welcome implements IMessage {
 
@@ -32,13 +32,7 @@ public class Welcome implements IMessage {
     }
 
     public static Welcome parse(List<Object> wmsg) {
-        if (wmsg.size() == 0 || !(wmsg.get(0) instanceof Integer) || (int) wmsg.get(0) != MESSAGE_TYPE) {
-            throw new IllegalArgumentException("Invalid message.");
-        }
-
-        if (wmsg.size() != 3) {
-            throw new ProtocolError(String.format("invalid message length %s for WELCOME", wmsg.size()));
-        }
+        MessageUtil.validateMessage(wmsg, MESSAGE_TYPE, "WELCOME", 3);
 
         long session = (long) wmsg.get(1);
 

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Yield.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Yield.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import io.crossbar.autobahn.wamp.exceptions.ProtocolError;
 import io.crossbar.autobahn.wamp.interfaces.IMessage;
 import io.crossbar.autobahn.wamp.utils.Cast;
+import io.crossbar.autobahn.wamp.utils.MessageUtil;
 
 public class Yield implements IMessage {
 
@@ -35,13 +36,7 @@ public class Yield implements IMessage {
     }
 
     public static Yield parse(List<Object> wmsg) {
-        if (wmsg.size() == 0 || !(wmsg.get(0) instanceof Integer) || (int) wmsg.get(0) != MESSAGE_TYPE) {
-            throw new IllegalArgumentException("Invalid message.");
-        }
-
-        if (wmsg.size() < 3 || wmsg.size() > 6) {
-            throw new ProtocolError(String.format("invalid message length %s for YIELD", wmsg.size()));
-        }
+        MessageUtil.validateMessage(wmsg, MESSAGE_TYPE, "YIELD", 3, 6);
 
         Map<String, Object> options = (Map<String, Object>) wmsg.get(2);
         List<Object> args = null;

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/utils/MessageUtil.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/utils/MessageUtil.java
@@ -1,0 +1,41 @@
+package io.crossbar.autobahn.wamp.utils;
+
+import java.util.List;
+
+import io.crossbar.autobahn.wamp.exceptions.ProtocolError;
+
+public class MessageUtil {
+
+    /**
+     * @param wmsg wamp message to validate
+     * @param messageType type of the wamp message
+     * @param lengthMin minimum number of items the wamp message is expected to have
+     * @param lengthMax maximum number of items the wamp message is expected to have
+     */
+    public static void validateMessage(List<Object> wmsg,
+                                       int messageType,
+                                       String messageVerboseName,
+                                       int lengthMin,
+                                       int lengthMax) {
+        if (wmsg.size() == 0 || !(wmsg.get(0) instanceof Integer) || (int) wmsg.get(0) != messageType) {
+            throw new IllegalArgumentException("Invalid message.");
+        }
+
+        if (wmsg.size() < lengthMin || wmsg.size() > lengthMax) {
+            throw new ProtocolError(String.format(
+                    "Invalid message length %s for %s", wmsg.size(), messageVerboseName));
+        }
+    }
+
+    /**
+     * @param wmsg wamp message to validate
+     * @param messageType type of the wamp message
+     * @param length number of items the wamp message is expected to have
+     */
+    public static void validateMessage(List<Object> wmsg,
+                                       int messageType,
+                                       String messageVerboseName,
+                                       int length) {
+        validateMessage(wmsg, messageType, messageVerboseName, length, length);
+    }
+}


### PR DESCRIPTION
We were doing code repetition in our message classes, lets reuse code.

PS: ABPy could use same love as well.