### PR TITLE
POJO enhancements

### DIFF
--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/Session.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/Session.java
@@ -21,6 +21,8 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ForkJoinPool;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 
 import io.crossbar.autobahn.wamp.exceptions.ApplicationError;
 import io.crossbar.autobahn.wamp.exceptions.ProtocolError;
@@ -392,6 +394,18 @@ public class Session implements ISession, ITransportHandler {
         mSubscribeRequests.put(requestID, new SubscribeRequest(requestID, topic, future, handler));
         this.send(new Subscribe(requestID, options, topic));
         return future;
+    }
+
+    @Override
+    public <T> CompletableFuture<Subscription> subscribe(String topic, Consumer<T> handler,
+                                                         SubscribeOptions options) {
+        return null;
+    }
+
+    @Override
+    public <T, U> CompletableFuture<Subscription> subscribe(String topic, BiConsumer<T, U> handler,
+                                                            SubscribeOptions options) {
+        return null;
     }
 
     private CompletableFuture<Publication> reallyPublish(String topic, List<Object> args,

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/Session.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/Session.java
@@ -135,6 +135,12 @@ public class Session implements ISession, ITransportHandler {
         return mExecutor;
     }
 
+    private void throwIfNotConnected() {
+        if (!isConnected()) {
+            throw new IllegalStateException("The transport must be connected first");
+        }
+    }
+
     @Override
     public void onConnect(ITransport transport, ISerializer serializer) {
         System.out.println("Session.onConnect");
@@ -386,9 +392,7 @@ public class Session implements ISession, ITransportHandler {
 
     @Override
     public CompletableFuture<Subscription> subscribe(String topic, IEventHandler handler, SubscribeOptions options) {
-        if (!isConnected()) {
-            throw new IllegalStateException("The transport must be connected first");
-        }
+        throwIfNotConnected();
         CompletableFuture<Subscription> future = new CompletableFuture<>();
         long requestID = mIDGenerator.next();
         mSubscribeRequests.put(requestID, new SubscribeRequest(requestID, topic, future, handler));
@@ -411,9 +415,7 @@ public class Session implements ISession, ITransportHandler {
     private CompletableFuture<Publication> reallyPublish(String topic, List<Object> args,
                                                          Map<String, Object> kwargs,
                                                          PublishOptions options) {
-        if (!isConnected()) {
-            throw new IllegalStateException("The transport must be connected first");
-        }
+        throwIfNotConnected();
         CompletableFuture<Publication> future = new CompletableFuture<>();
         long requestID = mIDGenerator.next();
         mPublishRequests.put(requestID, new PublishRequest(requestID, future));
@@ -461,9 +463,7 @@ public class Session implements ISession, ITransportHandler {
     @Override
     public CompletableFuture<Registration> register(String procedure, IInvocationHandler endpoint,
                                                     RegisterOptions options) {
-        if (!isConnected()) {
-            throw new IllegalStateException("The transport must be connected first");
-        }
+        throwIfNotConnected();
         CompletableFuture<Registration> future = new CompletableFuture<>();
         long requestID = mIDGenerator.next();
         mRegisterRequest.put(requestID, new RegisterRequest(requestID, future, procedure, endpoint));
@@ -477,9 +477,7 @@ public class Session implements ISession, ITransportHandler {
 
     private <T> CompletableFuture<T> reallyCall(String procedure, List<Object> args, Map<String, Object> kwargs,
                                                 TypeReference<T> resultType, CallOptions options) {
-        if (!isConnected()) {
-            throw new IllegalStateException("The transport must be connected first");
-        }
+        throwIfNotConnected();
 
         CompletableFuture<T> future = new CompletableFuture<>();
 

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/Session.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/Session.java
@@ -494,6 +494,12 @@ public class Session implements ISession, ITransportHandler {
     }
 
     @Override
+    public <T> CompletableFuture<T> call(String procedure, TypeReference<T> resultType, CallOptions options,
+                                         Object... args) {
+        return reallyCall(procedure, Arrays.asList(args), null, resultType, options);
+    }
+
+    @Override
     public CompletableFuture<SessionDetails> join(String realm, List<String> authMethods) {
         System.out.println("Session.join");
         mRealm = realm;

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/Session.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/Session.java
@@ -33,6 +33,7 @@ import io.crossbar.autobahn.wamp.interfaces.ISerializer;
 import io.crossbar.autobahn.wamp.interfaces.ISession;
 import io.crossbar.autobahn.wamp.interfaces.ITransport;
 import io.crossbar.autobahn.wamp.interfaces.ITransportHandler;
+import io.crossbar.autobahn.wamp.interfaces.TriConsumer;
 import io.crossbar.autobahn.wamp.messages.Call;
 import io.crossbar.autobahn.wamp.messages.Error;
 import io.crossbar.autobahn.wamp.messages.Event;
@@ -407,7 +408,13 @@ public class Session implements ISession, ITransportHandler {
     }
 
     @Override
-    public <T, U> CompletableFuture<Subscription> subscribe(String topic, BiConsumer<T, U> handler,
+    public <T> CompletableFuture<Subscription> subscribe(String topic, BiConsumer<T, EventDetails> handler,
+                                                         SubscribeOptions options) {
+        return null;
+    }
+
+    @Override
+    public <T, U> CompletableFuture<Subscription> subscribe(String topic, TriConsumer<T, U, EventDetails> handler,
                                                             SubscribeOptions options) {
         return null;
     }

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/Session.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/Session.java
@@ -22,6 +22,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ForkJoinPool;
 import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -486,6 +487,14 @@ public class Session implements ISession, ITransportHandler {
     @Override
     public <T> CompletableFuture<Registration> register(String procedure,
                                                         Function<T, CompletableFuture<InvocationResult>> endpoint,
+                                                        RegisterOptions options) {
+        return null;
+    }
+
+    @Override
+    public <T> CompletableFuture<Registration> register(String procedure,
+                                                        BiFunction<T, InvocationDetails,
+                                                                CompletableFuture<InvocationResult>> endpoint,
                                                         RegisterOptions options) {
         return null;
     }

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/Session.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/Session.java
@@ -393,9 +393,9 @@ public class Session implements ISession, ITransportHandler {
         return future;
     }
 
-    @Override
-    public CompletableFuture<Publication> publish(String topic, List<Object> args, Map<String, Object> kwargs,
-                                                  PublishOptions options) {
+    private CompletableFuture<Publication> reallyPublish(String topic, List<Object> args,
+                                                         Map<String, Object> kwargs,
+                                                         PublishOptions options) {
         if (!isConnected()) {
             throw new IllegalStateException("The transport must be connected first");
         }
@@ -408,6 +408,19 @@ public class Session implements ISession, ITransportHandler {
             this.send(new Publish(requestID, topic, args, kwargs, true, true));
         }
         return future;
+    }
+
+    @Override
+    public CompletableFuture<Publication> publish(String topic, List<Object> args, Map<String, Object> kwargs,
+                                                  PublishOptions options) {
+        return reallyPublish(topic, args, kwargs, options);
+    }
+
+    @Override
+    public CompletableFuture<Publication> publish(String topic, Object object, PublishOptions options) {
+        List<Object> args = new ArrayList<>();
+        args.add(object);
+        return reallyPublish(topic, args, null, options);
     }
 
     @Override

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/Session.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/Session.java
@@ -430,6 +430,11 @@ public class Session implements ISession, ITransportHandler {
     }
 
     @Override
+    public CompletableFuture<Publication> publish(String topic, Object... objects) {
+        return reallyPublish(topic, Arrays.asList(objects), null, null);
+    }
+
+    @Override
     public CompletableFuture<Publication> publish(String topic, PublishOptions options) {
         return reallyPublish(topic, null, null, options);
     }

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/Session.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/Session.java
@@ -430,6 +430,16 @@ public class Session implements ISession, ITransportHandler {
     }
 
     @Override
+    public CompletableFuture<Publication> publish(String topic, PublishOptions options) {
+        return reallyPublish(topic, null, null, options);
+    }
+
+    @Override
+    public CompletableFuture<Publication> publish(String topic) {
+        return reallyPublish(topic, null, null, null);
+    }
+
+    @Override
     public CompletableFuture<Registration> register(String procedure, IInvocationHandler endpoint,
                                                     RegisterOptions options) {
         if (!isConnected()) {

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/Session.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/Session.java
@@ -23,6 +23,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ForkJoinPool;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 import io.crossbar.autobahn.wamp.exceptions.ApplicationError;
 import io.crossbar.autobahn.wamp.exceptions.ProtocolError;
@@ -480,6 +481,13 @@ public class Session implements ISession, ITransportHandler {
             this.send(new Register(requestID, procedure, null, null));
         }
         return future;
+    }
+
+    @Override
+    public <T> CompletableFuture<Registration> register(String procedure,
+                                                        Function<T, CompletableFuture<InvocationResult>> endpoint,
+                                                        RegisterOptions options) {
+        return null;
     }
 
     private <T> CompletableFuture<T> reallyCall(String procedure, List<Object> args, Map<String, Object> kwargs,

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/Session.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/Session.java
@@ -14,6 +14,7 @@ package io.crossbar.autobahn.wamp;
 import com.fasterxml.jackson.core.type.TypeReference;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -421,6 +422,11 @@ public class Session implements ISession, ITransportHandler {
         List<Object> args = new ArrayList<>();
         args.add(object);
         return reallyPublish(topic, args, null, options);
+    }
+
+    @Override
+    public CompletableFuture<Publication> publish(String topic, PublishOptions options, Object... objects) {
+        return reallyPublish(topic, Arrays.asList(objects), null, options);
     }
 
     @Override

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/interfaces/IEventHandler.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/interfaces/IEventHandler.java
@@ -18,8 +18,8 @@ import io.crossbar.autobahn.wamp.types.EventDetails;
 
 
 @FunctionalInterface
-public interface IEventHandler<R> {
-    R run(List<Object> args,
-          Map<String, Object> kwargs,
-          EventDetails details);
+public interface IEventHandler {
+    void run(List<Object> args,
+             Map<String, Object> kwargs,
+             EventDetails details);
 }

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/interfaces/IEventHandler.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/interfaces/IEventHandler.java
@@ -19,7 +19,7 @@ import io.crossbar.autobahn.wamp.types.EventDetails;
 
 @FunctionalInterface
 public interface IEventHandler {
-    void run(List<Object> args,
-             Map<String, Object> kwargs,
-             EventDetails details);
+    void accept(List<Object> args,
+                Map<String, Object> kwargs,
+                EventDetails details);
 }

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/interfaces/IInvocationHandler.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/interfaces/IInvocationHandler.java
@@ -21,7 +21,7 @@ import io.crossbar.autobahn.wamp.types.InvocationResult;
 
 @FunctionalInterface
 public interface IInvocationHandler {
-    CompletableFuture<InvocationResult> run(List<Object> args,
-                                            Map<String, Object> kwargs,
-                                            InvocationDetails details);
+    CompletableFuture<InvocationResult> apply(List<Object> args,
+                                              Map<String, Object> kwargs,
+                                              InvocationDetails details);
 }

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/interfaces/ISession.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/interfaces/ISession.java
@@ -43,6 +43,8 @@ public interface ISession {
 
     CompletableFuture<Publication> publish(String topic, PublishOptions options, Object... objects);
 
+    CompletableFuture<Publication> publish(String topic, Object... objects);
+
     CompletableFuture<Publication> publish(String topic, PublishOptions options);
 
     CompletableFuture<Publication> publish(String topic);

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/interfaces/ISession.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/interfaces/ISession.java
@@ -41,6 +41,8 @@ public interface ISession {
 
     CompletableFuture<Publication> publish(String topic, Object object, PublishOptions options);
 
+    CompletableFuture<Publication> publish(String topic, PublishOptions options, Object... objects);
+
     CompletableFuture<Registration> register(String procedure, IInvocationHandler endpoint, RegisterOptions options);
 
     CompletableFuture<CallResult> call(String procedure,

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/interfaces/ISession.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/interfaces/ISession.java
@@ -76,6 +76,11 @@ public interface ISession {
                                                          CompletableFuture<InvocationResult>> endpoint,
                                                  RegisterOptions options);
 
+    <T, U> CompletableFuture<Registration> register(String procedure,
+                                                    TriFunction<T, U, InvocationDetails,
+                                                            CompletableFuture<InvocationResult>> endpoint,
+                                                    RegisterOptions options);
+
     CompletableFuture<CallResult> call(String procedure,
                                        List<Object> args,
                                        Map<String, Object> kwargs,

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/interfaces/ISession.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/interfaces/ISession.java
@@ -18,12 +18,14 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 import io.crossbar.autobahn.wamp.Session;
 import io.crossbar.autobahn.wamp.types.CallOptions;
 import io.crossbar.autobahn.wamp.types.CallResult;
 import io.crossbar.autobahn.wamp.types.CloseDetails;
 import io.crossbar.autobahn.wamp.types.EventDetails;
+import io.crossbar.autobahn.wamp.types.InvocationResult;
 import io.crossbar.autobahn.wamp.types.Publication;
 import io.crossbar.autobahn.wamp.types.PublishOptions;
 import io.crossbar.autobahn.wamp.types.RegisterOptions;
@@ -62,6 +64,10 @@ public interface ISession {
 
     CompletableFuture<Registration> register(String procedure, IInvocationHandler endpoint,
                                              RegisterOptions options);
+
+    <T> CompletableFuture<Registration> register(String procedure,
+                                                 Function<T, CompletableFuture<InvocationResult>> endpoint,
+                                                 RegisterOptions options);
 
     CompletableFuture<CallResult> call(String procedure,
                                        List<Object> args,

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/interfaces/ISession.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/interfaces/ISession.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -25,6 +26,7 @@ import io.crossbar.autobahn.wamp.types.CallOptions;
 import io.crossbar.autobahn.wamp.types.CallResult;
 import io.crossbar.autobahn.wamp.types.CloseDetails;
 import io.crossbar.autobahn.wamp.types.EventDetails;
+import io.crossbar.autobahn.wamp.types.InvocationDetails;
 import io.crossbar.autobahn.wamp.types.InvocationResult;
 import io.crossbar.autobahn.wamp.types.Publication;
 import io.crossbar.autobahn.wamp.types.PublishOptions;
@@ -67,6 +69,11 @@ public interface ISession {
 
     <T> CompletableFuture<Registration> register(String procedure,
                                                  Function<T, CompletableFuture<InvocationResult>> endpoint,
+                                                 RegisterOptions options);
+
+    <T> CompletableFuture<Registration> register(String procedure,
+                                                 BiFunction<T, InvocationDetails,
+                                                         CompletableFuture<InvocationResult>> endpoint,
                                                  RegisterOptions options);
 
     CompletableFuture<CallResult> call(String procedure,

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/interfaces/ISession.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/interfaces/ISession.java
@@ -23,6 +23,7 @@ import io.crossbar.autobahn.wamp.Session;
 import io.crossbar.autobahn.wamp.types.CallOptions;
 import io.crossbar.autobahn.wamp.types.CallResult;
 import io.crossbar.autobahn.wamp.types.CloseDetails;
+import io.crossbar.autobahn.wamp.types.EventDetails;
 import io.crossbar.autobahn.wamp.types.Publication;
 import io.crossbar.autobahn.wamp.types.PublishOptions;
 import io.crossbar.autobahn.wamp.types.RegisterOptions;
@@ -38,7 +39,10 @@ public interface ISession {
 
     <T> CompletableFuture<Subscription> subscribe(String topic, Consumer<T> handler, SubscribeOptions options);
 
-    <T, U> CompletableFuture<Subscription> subscribe(String topic, BiConsumer<T, U> handler,
+    <T> CompletableFuture<Subscription> subscribe(String topic, BiConsumer<T, EventDetails> handler,
+                                                  SubscribeOptions options);
+
+    <T, U> CompletableFuture<Subscription> subscribe(String topic, TriConsumer<T, U, EventDetails> handler,
                                                      SubscribeOptions options);
 
     CompletableFuture<Publication> publish(String topic,
@@ -56,7 +60,8 @@ public interface ISession {
 
     CompletableFuture<Publication> publish(String topic);
 
-    CompletableFuture<Registration> register(String procedure, IInvocationHandler endpoint, RegisterOptions options);
+    CompletableFuture<Registration> register(String procedure, IInvocationHandler endpoint,
+                                             RegisterOptions options);
 
     CompletableFuture<CallResult> call(String procedure,
                                        List<Object> args,

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/interfaces/ISession.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/interfaces/ISession.java
@@ -39,6 +39,8 @@ public interface ISession {
                                            Map<String, Object> kwargs,
                                            PublishOptions options);
 
+    CompletableFuture<Publication> publish(String topic, Object object, PublishOptions options);
+
     CompletableFuture<Registration> register(String procedure, IInvocationHandler endpoint, RegisterOptions options);
 
     CompletableFuture<CallResult> call(String procedure,

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/interfaces/ISession.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/interfaces/ISession.java
@@ -16,6 +16,8 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 
 import io.crossbar.autobahn.wamp.Session;
 import io.crossbar.autobahn.wamp.types.CallOptions;
@@ -33,6 +35,11 @@ import io.crossbar.autobahn.wamp.types.Subscription;
 public interface ISession {
 
     CompletableFuture<Subscription> subscribe(String topic, IEventHandler handler, SubscribeOptions options);
+
+    <T> CompletableFuture<Subscription> subscribe(String topic, Consumer<T> handler, SubscribeOptions options);
+
+    <T, U> CompletableFuture<Subscription> subscribe(String topic, BiConsumer<T, U> handler,
+                                                     SubscribeOptions options);
 
     CompletableFuture<Publication> publish(String topic,
                                            List<Object> args,

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/interfaces/ISession.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/interfaces/ISession.java
@@ -61,12 +61,12 @@ public interface ISession {
                                   Map<String, Object> kwargs,
                                   TypeReference<T> resultType,
                                   CallOptions options);
-/*
+
     <T> CompletableFuture<T> call(String procedure,
                                   TypeReference<T> resultType,
                                   CallOptions options,
                                   Object... args);
-*/
+
     CompletableFuture<SessionDetails> join(String realm, List<String> authMethods);
 
     void leave(String reason, String message);

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/interfaces/ISession.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/interfaces/ISession.java
@@ -43,6 +43,10 @@ public interface ISession {
 
     CompletableFuture<Publication> publish(String topic, PublishOptions options, Object... objects);
 
+    CompletableFuture<Publication> publish(String topic, PublishOptions options);
+
+    CompletableFuture<Publication> publish(String topic);
+
     CompletableFuture<Registration> register(String procedure, IInvocationHandler endpoint, RegisterOptions options);
 
     CompletableFuture<CallResult> call(String procedure,

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/interfaces/TriConsumer.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/interfaces/TriConsumer.java
@@ -1,0 +1,7 @@
+package io.crossbar.autobahn.wamp.interfaces;
+
+
+@FunctionalInterface
+public interface TriConsumer<T, U, V> {
+    void accept(T var1, U var2, V var3);
+}

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/interfaces/TriFunction.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/interfaces/TriFunction.java
@@ -1,0 +1,6 @@
+package io.crossbar.autobahn.wamp.interfaces;
+
+@FunctionalInterface
+public interface TriFunction<T, U, V, R> {
+    R apply(T var1, U var2, V var3);
+}

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/requests/RegisterRequest.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/requests/RegisterRequest.java
@@ -13,17 +13,16 @@ package io.crossbar.autobahn.wamp.requests;
 
 import java.util.concurrent.CompletableFuture;
 
-import io.crossbar.autobahn.wamp.interfaces.IInvocationHandler;
 import io.crossbar.autobahn.wamp.types.Registration;
 
 
 public class RegisterRequest extends Request {
     public final CompletableFuture<Registration> onReply;
     public final String procedure;
-    public final IInvocationHandler endpoint;
+    public final Object endpoint;
 
     public RegisterRequest(long request, CompletableFuture<Registration> onReply, String procedure,
-                           IInvocationHandler endpoint) {
+                           Object endpoint) {
         super(request);
         this.onReply = onReply;
         this.procedure = procedure;

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/requests/SubscribeRequest.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/requests/SubscribeRequest.java
@@ -13,17 +13,16 @@ package io.crossbar.autobahn.wamp.requests;
 
 import java.util.concurrent.CompletableFuture;
 
-import io.crossbar.autobahn.wamp.interfaces.IEventHandler;
 import io.crossbar.autobahn.wamp.types.Subscription;
 
 
 public class SubscribeRequest extends Request {
     public final String topic;
     public final CompletableFuture<Subscription> onReply;
-    public final IEventHandler handler;
+    public final Object handler;
 
     public SubscribeRequest(long request, String topic, CompletableFuture<Subscription> onReply,
-                            IEventHandler handler) {
+                            Object handler) {
         super(request);
         this.topic = topic;
         this.onReply = onReply;

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/requests/SubscribeRequest.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/requests/SubscribeRequest.java
@@ -20,10 +20,10 @@ import io.crossbar.autobahn.wamp.types.Subscription;
 public class SubscribeRequest extends Request {
     public final String topic;
     public final CompletableFuture<Subscription> onReply;
-    public final IEventHandler<?> handler;
+    public final IEventHandler handler;
 
     public SubscribeRequest(long request, String topic, CompletableFuture<Subscription> onReply,
-                            IEventHandler<?> handler) {
+                            IEventHandler handler) {
         super(request);
         this.topic = topic;
         this.onReply = onReply;

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/types/InvocationResult.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/types/InvocationResult.java
@@ -17,11 +17,13 @@ import java.util.Map;
 
 
 public class InvocationResult {
-    public List<Object> results;
-    public Map<String, Object> kwresults;
+    public final List<Object> results;
+    public final Map<String, Object> kwresults;
 
     /// Default constructor.
     public InvocationResult() {
+        results = null;
+        kwresults = null;
     }
 
     /// Copy constructor.
@@ -34,16 +36,19 @@ public class InvocationResult {
     public InvocationResult(Object result) {
         this.results = new ArrayList<>();
         this.results.add(result);
+        this.kwresults = null;
     }
 
     /// Constructor for positional-only results.
     public InvocationResult(List<Object> results) {
         this.results = results;
+        this.kwresults = null;
     }
 
     /// Constructor for keyword-based-only results.
     public InvocationResult(Map<String, Object> kwresults) {
         this.kwresults = kwresults;
+        this.results = null;
     }
 
     /// Constructor for results that have both positional and keyword-based results.

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/types/Registration.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/types/Registration.java
@@ -11,15 +11,12 @@
 
 package io.crossbar.autobahn.wamp.types;
 
-import io.crossbar.autobahn.wamp.interfaces.IInvocationHandler;
-
-
 public class Registration {
     public final long registration;
     public final String procedure;
-    public final IInvocationHandler endpoint;
+    public final Object endpoint;
 
-    public Registration(long registration, String procedure, IInvocationHandler endpoint) {
+    public Registration(long registration, String procedure, Object endpoint) {
         this.registration = registration;
         this.procedure = procedure;
         this.endpoint = endpoint;

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/types/Subscription.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/types/Subscription.java
@@ -11,15 +11,12 @@
 
 package io.crossbar.autobahn.wamp.types;
 
-import io.crossbar.autobahn.wamp.interfaces.IEventHandler;
-
-
 public class Subscription {
     public final long subscription;
     public final String topic;
-    public final IEventHandler handler;
+    public final Object handler;
 
-    public Subscription(long subscription, String topic, IEventHandler handler) {
+    public Subscription(long subscription, String topic, Object handler) {
         this.subscription = subscription;
         this.topic = topic;
         this.handler = handler;

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/types/Subscription.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/types/Subscription.java
@@ -17,9 +17,9 @@ import io.crossbar.autobahn.wamp.interfaces.IEventHandler;
 public class Subscription {
     public final long subscription;
     public final String topic;
-    public final IEventHandler<?> handler;
+    public final IEventHandler handler;
 
-    public Subscription(long subscription, String topic, IEventHandler<?> handler) {
+    public Subscription(long subscription, String topic, IEventHandler handler) {
         this.subscription = subscription;
         this.topic = topic;
         this.handler = handler;

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ buildscript {
     // Netty build does not need android dependencies.
     if (project.properties.get('buildPlatform', 'android') == 'android') {
         dependencies {
-            classpath 'com.android.tools.build:gradle:3.0.0-alpha4'
+            classpath 'com.android.tools.build:gradle:3.0.0-alpha5'
         }
     }
 }

--- a/demo-gallery/src/main/java/io/crossbar/autobahn/demogallery/netty/Service.java
+++ b/demo-gallery/src/main/java/io/crossbar/autobahn/demogallery/netty/Service.java
@@ -11,6 +11,8 @@
 
 package io.crossbar.autobahn.demogallery.netty;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -20,21 +22,15 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-
 import io.crossbar.autobahn.wamp.Client;
 import io.crossbar.autobahn.wamp.Session;
-
-import io.crossbar.autobahn.wamp.transports.NettyTransport;
-
 import io.crossbar.autobahn.wamp.auth.AnonymousAuth;
-
 import io.crossbar.autobahn.wamp.interfaces.IAuthenticator;
 import io.crossbar.autobahn.wamp.interfaces.ITransport;
-
+import io.crossbar.autobahn.wamp.transports.NettyTransport;
 import io.crossbar.autobahn.wamp.types.CallResult;
-import io.crossbar.autobahn.wamp.types.ExitInfo;
 import io.crossbar.autobahn.wamp.types.EventDetails;
+import io.crossbar.autobahn.wamp.types.ExitInfo;
 import io.crossbar.autobahn.wamp.types.InvocationDetails;
 import io.crossbar.autobahn.wamp.types.InvocationResult;
 import io.crossbar.autobahn.wamp.types.Publication;
@@ -318,9 +314,12 @@ public class Service {
 
 
     // this handler will process incoming events for the topic we subscribe it to
-    private Void onCounter(List<Object> args, Map<String, Object> kwargs, EventDetails details) {
+    private void onCounter(List<Object> args, Map<String, Object> kwargs, EventDetails details) {
         System.out.println("received counter: " + args.get(0));
-        return null;
+    }
+
+    private void onCounterSimple(String object, EventDetails details) {
+        System.out.println("received counter: " + object);
     }
 
 


### PR DESCRIPTION
- Add multiple Session.publish() implementations
- Add back convenience Session.call() aka max-comfort.

@oberstet We can add more convenience methods to Session.call() as well like you can see for Session.publish(), are you fine with more convenience methods ?

Also it is still not clear how the signature of a method that sends a list of POJOs would look like.