### PR TITLE
demo-gallery: Allow setting log level from commandline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ java:
 		--link crossbar \
 		-v ${shell pwd}:/workspace \
 		crossbario/autobahn-java:netty \
-			/bin/bash -c "gradle installDist -PbuildPlatform=netty && demo-gallery/build/install/demo-gallery/bin/demo-gallery ws://crossbar:8080/ws"
+			/bin/bash -c "gradle installDist -PbuildPlatform=netty && DEMO_GALLERY_OPTS="-DlogLevel=INFO" demo-gallery/build/install/demo-gallery/bin/demo-gallery ws://crossbar:8080/ws"
 
 #
 # Toolchain

--- a/demo-gallery/src/main/java/io/crossbar/autobahn/demogallery/netty/Main.java
+++ b/demo-gallery/src/main/java/io/crossbar/autobahn/demogallery/netty/Main.java
@@ -11,16 +11,27 @@
 
 package io.crossbar.autobahn.demogallery.netty;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.logging.LogManager;
 import java.util.logging.Logger;
 
 
 public class Main {
 
+    private static final String LOG_CONFIG = "handlers= java.util.logging.ConsoleHandler\n"
+            + ".level = %s\n" +
+            "java.util.logging.ConsoleHandler.level = %s\n" +
+            "java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter\n";
     private static final Logger LOGGER = Logger.getLogger(Main.class.getName());
 
-    public static void main(String[] args) {
+    public static void main(String[] args) throws IOException {
+
+        readAndSetLogLevel();
 
         ExecutorService executor = Executors.newSingleThreadExecutor();
 
@@ -47,5 +58,12 @@ public class Main {
         LOGGER.info(String.format(".. ended with return code %s", returnCode));
 
         System.exit(returnCode);
+    }
+
+    private static void readAndSetLogLevel() throws IOException {
+        String logLevel = System.getProperty("logLevel", "INFO");
+        String config = String.format(LOG_CONFIG, logLevel, logLevel);
+        InputStream stream = new ByteArrayInputStream(config.getBytes(StandardCharsets.UTF_8));
+        LogManager.getLogManager().readConfiguration(stream);
     }
 }


### PR DESCRIPTION
Our java code reads systemProperty named `logLevel`, if its missing or something invalid, we default log level to INFO.

The "right" way(to my knowledge) in java to set logging config for an app is using logging.properties file, a file however limits our capability to be dynamic. So what I introduced is I create a file input stream based on logging.properties structure which is dynamically populated.