### PR TITLE
Comply with the specification

### DIFF
--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Publish.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Publish.java
@@ -81,8 +81,12 @@ public class Publish implements IMessage {
         marshaled.add(MESSAGE_TYPE);
         marshaled.add(request);
         Map<String, Object> options = new HashMap<>();
-        options.put("acknowledge", acknowledge);
-        options.put("exclude_me", excludeMe);
+        if (acknowledge) {
+        	options.put("acknowledge", acknowledge);
+        }
+        if (!excludeMe) {
+        	options.put("exclude_me", excludeMe);
+        }
         marshaled.add(options);
         marshaled.add(topic);
         if (kwargs != null) {

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Subscribe.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Subscribe.java
@@ -70,8 +70,12 @@ public class Subscribe implements IMessage {
         marshaled.add(MESSAGE_TYPE);
         marshaled.add(request);
         Map<String, Object> extra = new HashMap<>();
-        extra.put("match", match);
-        extra.put("get_retained", getRetained);
+        if (!Objects.equals(match, MATCH_EXACT)) {
+        	extra.put("match", match);
+        }
+        if (getRetained) {
+        	extra.put("get_retained", getRetained);
+        }
         marshaled.add(extra);
         marshaled.add(topic);
         return marshaled;

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Unregistered.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Unregistered.java
@@ -12,9 +12,7 @@
 package io.crossbar.autobahn.wamp.messages;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import io.crossbar.autobahn.wamp.interfaces.IMessage;
 import io.crossbar.autobahn.wamp.utils.MessageUtil;
@@ -23,29 +21,15 @@ public class Unregistered implements IMessage {
 
     public static final int MESSAGE_TYPE = 67;
 
-    private static final long REGISTRATION_NULL = -1;
     private final long request;
-    private final long registration;
-    private final String reason;
 
-    public Unregistered(long request, long registration, String reason) {
+    public Unregistered(long request) {
         this.request = request;
-        this.registration = registration;
-        this.reason = reason;
     }
 
     public static Unregistered parse(List<Object> wmsg) {
         MessageUtil.validateMessage(wmsg, MESSAGE_TYPE, "UNREGISTERED", 2, 3);
-
-        long registration = REGISTRATION_NULL;
-        String reason = null;
-        if (wmsg.size() > 2) {
-            Map<String, Object> details = (Map<String, Object>) wmsg.get(2);
-            registration = (long) details.getOrDefault("registration", registration);
-            reason = (String) details.getOrDefault("reason", reason);
-        }
-
-        return new Unregistered(MessageUtil.parseRequestID(wmsg.get(1)), registration, reason);
+        return new Unregistered(MessageUtil.parseRequestID(wmsg.get(1)));
     }
 
     @Override
@@ -53,16 +37,6 @@ public class Unregistered implements IMessage {
         List<Object> marshaled = new ArrayList<>();
         marshaled.add(MESSAGE_TYPE);
         marshaled.add(request);
-        if (registration != REGISTRATION_NULL || reason != null) {
-            Map<String, Object> details = new HashMap<>();
-            if (reason != null) {
-                details.put("reason", reason);
-            }
-            if (registration != REGISTRATION_NULL) {
-                details.put("registration", registration);
-            }
-            marshaled.add(details);
-        }
         return marshaled;
     }
 }

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Unsubscribed.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Unsubscribed.java
@@ -12,9 +12,7 @@
 package io.crossbar.autobahn.wamp.messages;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import io.crossbar.autobahn.wamp.interfaces.IMessage;
 import io.crossbar.autobahn.wamp.utils.MessageUtil;
@@ -23,35 +21,15 @@ public class Unsubscribed implements IMessage {
 
     public static final int MESSAGE_TYPE = 35;
 
-    private static final long SUBSCRIPTION_NULL = -1;
     private final long request;
-    private final long subscription;
-    private final String reason;
 
-    public Unsubscribed(long request, long subscription, String reason) {
+    public Unsubscribed(long request) {
         this.request = request;
-        this.subscription = subscription;
-        this.reason = reason;
     }
 
     public static Unsubscribed parse(List<Object> wmsg) {
-        MessageUtil.validateMessage(wmsg, MESSAGE_TYPE, "UNSUBSCRIBED", 2, 3);
-
-        long request = MessageUtil.parseRequestID(wmsg.get(1));
-
-        long subscription = SUBSCRIPTION_NULL;
-        String reason = null;
-        if (wmsg.size() > 2) {
-            Map<String, Object> details = (Map<String, Object>) wmsg.get(2);
-            if (details.containsKey("subscription")) {
-                subscription = (long) details.get("subscription");
-            }
-            if (details.containsKey("reason")) {
-                reason = (String) details.get("reason");
-            }
-        }
-
-        return new Unsubscribed(request, subscription, reason);
+        MessageUtil.validateMessage(wmsg, MESSAGE_TYPE, "UNSUBSCRIBED", 2);
+        return new Unsubscribed(MessageUtil.parseRequestID(wmsg.get(1)));
     }
 
     @Override
@@ -59,16 +37,6 @@ public class Unsubscribed implements IMessage {
         List<Object> marshaled = new ArrayList<>();
         marshaled.add(MESSAGE_TYPE);
         marshaled.add(request);
-        if (subscription != SUBSCRIPTION_NULL || reason != null) {
-            Map<String, Object> details = new HashMap<>();
-            if (reason != null) {
-                details.put("reason", reason);
-            }
-            if (subscription != SUBSCRIPTION_NULL) {
-                details.put("subscription", subscription);
-            }
-            marshaled.add(details);
-        }
         return marshaled;
     }
 }


### PR DESCRIPTION
Both UNREGISTERED and UNSUBSCRIBED consist only of the code and the requestId according to the specification

Example:
[67, 788923562]
[35, 85346237]

http://wamp-proto.org/static/rfc/draft-oberstet-hybi-crossbar-wamp.html#unsubscribed-1
http://wamp-proto.org/static/rfc/draft-oberstet-hybi-crossbar-wamp.html#unregistered-1