### PR TITLE
Utilize Collections.empty... helper methods to create empty collections.

### DIFF
--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Call.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Call.java
@@ -12,6 +12,7 @@
 package io.crossbar.autobahn.wamp.messages;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -83,7 +84,7 @@ public class Call implements IMessage {
         if (kwargs != null) {
             if (args == null) {
                 // Empty args.
-                marshaled.add(new ArrayList<String>());
+                marshaled.add(Collections.emptyList());
             } else {
                 marshaled.add(args);
             }

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Cancel.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Cancel.java
@@ -12,6 +12,7 @@
 package io.crossbar.autobahn.wamp.messages;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -60,7 +61,7 @@ public class Cancel implements IMessage {
             marshaled.add(options);
         } else {
             // Empty options as third item.
-            marshaled.add(new HashMap<>());
+            marshaled.add(Collections.emptyMap());
         }
         return marshaled;
     }

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Error.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Error.java
@@ -12,6 +12,7 @@
 package io.crossbar.autobahn.wamp.messages;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -76,7 +77,7 @@ public class Error implements IMessage {
         if (kwargs != null) {
             if (args == null) {
                 // Empty args.
-                marshaled.add(new ArrayList<String>());
+                marshaled.add(Collections.emptyList());
             } else {
                 marshaled.add(args);
             }

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Event.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Event.java
@@ -12,6 +12,7 @@
 package io.crossbar.autobahn.wamp.messages;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -62,11 +63,11 @@ public class Event implements IMessage {
         marshaled.add(subscription);
         marshaled.add(publication);
         // Empty details.
-        marshaled.add(new HashMap<>());
+        marshaled.add(Collections.emptyMap());
         if (kwargs != null) {
             if (args == null) {
                 // Empty args.
-                marshaled.add(new ArrayList<String>());
+                marshaled.add(Collections.emptyList());
             } else {
                 marshaled.add(args);
             }

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Interrupt.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Interrupt.java
@@ -12,6 +12,7 @@
 package io.crossbar.autobahn.wamp.messages;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -61,7 +62,7 @@ public class Interrupt implements IMessage {
             marshaled.add(options);
         } else {
             // Empty options as third item.
-            marshaled.add(new HashMap<>());
+            marshaled.add(Collections.emptyMap());
         }
         return marshaled;
     }

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Invocation.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Invocation.java
@@ -12,6 +12,7 @@
 package io.crossbar.autobahn.wamp.messages;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -63,11 +64,11 @@ public class Invocation implements IMessage {
         marshaled.add(request);
         marshaled.add(registration);
         // Empty options.
-        marshaled.add(new HashMap<>());
+        marshaled.add(Collections.emptyMap());
         if (kwargs != null) {
             if (args == null) {
                 // Empty args.
-                marshaled.add(new ArrayList<String>());
+                marshaled.add(Collections.emptyList());
             } else {
                 marshaled.add(args);
             }

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Publish.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Publish.java
@@ -12,6 +12,7 @@
 package io.crossbar.autobahn.wamp.messages;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -88,7 +89,7 @@ public class Publish implements IMessage {
         if (kwargs != null) {
             if (args == null) {
                 // Empty args.
-                marshaled.add(new ArrayList<String>());
+                marshaled.add(Collections.emptyList());
             } else {
                 marshaled.add(args);
             }

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Result.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Result.java
@@ -12,6 +12,7 @@
 package io.crossbar.autobahn.wamp.messages;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -56,11 +57,11 @@ public class Result implements IMessage {
         List<Object> marshaled = new ArrayList<>();
         marshaled.add(MESSAGE_TYPE);
         marshaled.add(request);
-        marshaled.add(new HashMap<>());
+        marshaled.add(Collections.emptyMap());
         if (kwargs != null) {
             if (args == null) {
                 // Empty args.
-                marshaled.add(new ArrayList<String>());
+                marshaled.add(Collections.emptyList());
             } else {
                 marshaled.add(args);
             }

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Yield.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Yield.java
@@ -12,6 +12,7 @@
 package io.crossbar.autobahn.wamp.messages;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -58,11 +59,11 @@ public class Yield implements IMessage {
         marshaled.add(MESSAGE_TYPE);
         marshaled.add(request);
         // Empty options.
-        marshaled.add(new HashMap<>());
+        marshaled.add(Collections.emptyMap());
         if (kwargs != null) {
             if (args == null) {
                 // Empty args.
-                marshaled.add(new ArrayList<String>());
+                marshaled.add(Collections.emptyList());
             } else {
                 marshaled.add(args);
             }


### PR DESCRIPTION
Instead of creating empty collections it's a bit more efficient to use the helper methods from java.util.Collections. These methods do not create a new object when they are called, instead they return a
singleton object.