### PR TITLE
Complete event retention support and add Event.topic property

### DIFF
--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/Session.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/Session.java
@@ -587,9 +587,9 @@ public class Session implements ISession, ITransportHandler {
         long requestID = mIDGenerator.next();
         mPublishRequests.put(requestID, new PublishRequest(requestID, future));
         if (options != null) {
-            send(new Publish(requestID, topic, args, kwargs, options.acknowledge, options.excludeMe));
+            send(new Publish(requestID, topic, args, kwargs, options.acknowledge, options.excludeMe, options.retain));
         } else {
-            send(new Publish(requestID, topic, args, kwargs, true, true));
+            send(new Publish(requestID, topic, args, kwargs, true, true, false));
         }
         return future;
     }

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/Session.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/Session.java
@@ -286,7 +286,9 @@ public class Session implements ISession, ITransportHandler {
 
                 subscriptions.forEach(subscription -> {
                             EventDetails details = new EventDetails(
-                                    subscription, subscription.topic, -1, null, null, this);
+                                    subscription, msg.publication, 
+                                    msg.topic != null ? msg.topic : subscription.topic, 
+                                    msg.retained, -1, null, null, this);
 
                             CompletableFuture future = null;
                             if (subscription.handler instanceof Consumer) {

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Event.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Event.java
@@ -45,11 +45,11 @@ public class Event implements IMessage {
         MessageUtil.validateMessage(wmsg, MESSAGE_TYPE, "EVENT", 3, 6);
         long subscription = (long) wmsg.get(1);
         long publication = (long) wmsg.get(2);
-        
+
         Map<String, Object> details = (Map<String, Object>) wmsg.get(3);
         String topic = (String)details.get("topic");
         boolean retained = (boolean)details.getOrDefault("retained", false);
-        
+
         List<Object> args = null;
         if (wmsg.size() > 4) {
             if (wmsg.get(4) instanceof byte[]) {
@@ -73,10 +73,10 @@ public class Event implements IMessage {
         marshaled.add(publication);
         Map<String, Object> details = new HashMap<>();
         if (topic != null) {
-			details.put("topic", topic);
-		}
+            details.put("topic", topic);
+        }
         if (retained) {
-        	details.put("retained", retained);
+            details.put("retained", retained);
         }
         marshaled.add(details);
         if (kwargs != null) {

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Event.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Event.java
@@ -27,12 +27,16 @@ public class Event implements IMessage {
 
     public final long subscription;
     public final long publication;
+    public final String topic;
+    public final boolean retained;
     public final List<Object> args;
     public final Map<String, Object> kwargs;
 
-    public Event(long subscription, long publication, List<Object> args, Map<String, Object> kwargs) {
+    public Event(long subscription, long publication, String topic, boolean retained, List<Object> args, Map<String, Object> kwargs) {
         this.subscription = subscription;
         this.publication = publication;
+        this.topic = topic;
+        this.retained = retained;
         this.args = args;
         this.kwargs = kwargs;
     }
@@ -41,7 +45,11 @@ public class Event implements IMessage {
         MessageUtil.validateMessage(wmsg, MESSAGE_TYPE, "EVENT", 3, 6);
         long subscription = (long) wmsg.get(1);
         long publication = (long) wmsg.get(2);
+        
         Map<String, Object> details = (Map<String, Object>) wmsg.get(3);
+        String topic = (String)details.get("topic");
+        boolean retained = (boolean)details.getOrDefault("retained", false);
+        
         List<Object> args = null;
         if (wmsg.size() > 4) {
             if (wmsg.get(4) instanceof byte[]) {
@@ -53,7 +61,8 @@ public class Event implements IMessage {
         if (wmsg.size() > 5) {
             kwargs = (Map<String, Object>) wmsg.get(5);
         }
-        return new Event(subscription, publication, args, kwargs);
+
+        return new Event(subscription, publication, topic, retained, args, kwargs);
     }
 
     @Override
@@ -62,8 +71,14 @@ public class Event implements IMessage {
         marshaled.add(MESSAGE_TYPE);
         marshaled.add(subscription);
         marshaled.add(publication);
-        // Empty details.
-        marshaled.add(Collections.emptyMap());
+        Map<String, Object> details = new HashMap<>();
+        if (topic != null) {
+			details.put("topic", topic);
+		}
+        if (retained) {
+        	details.put("retained", retained);
+        }
+        marshaled.add(details);
         if (kwargs != null) {
             if (args == null) {
                 // Empty args.

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Publish.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Publish.java
@@ -24,7 +24,7 @@ import io.crossbar.autobahn.wamp.utils.MessageUtil;
 public class Publish implements IMessage {
 
     public static final int MESSAGE_TYPE = 16;
-    
+
     public final long request;
     public final String topic;
     public final List<Object> args;
@@ -68,7 +68,7 @@ public class Publish implements IMessage {
         boolean acknowledge = (boolean)options.getOrDefault("acknowledge", false);
         boolean excludeMe = (boolean)options.getOrDefault("exclude_me", true);
         boolean retain = (boolean)options.getOrDefault("retain", false);
-        
+
         return new Publish(request, topic, args, kwargs, acknowledge, excludeMe, retain);
     }
 
@@ -79,13 +79,13 @@ public class Publish implements IMessage {
         marshaled.add(request);
         Map<String, Object> options = new HashMap<>();
         if (acknowledge) {
-        	options.put("acknowledge", acknowledge);
+            options.put("acknowledge", acknowledge);
         }
         if (!excludeMe) {
-        	options.put("exclude_me", excludeMe);
+            options.put("exclude_me", excludeMe);
         }
         if (retain) {
-        	options.put("retain", retain);
+            options.put("retain", retain);
         }
         marshaled.add(options);
         marshaled.add(topic);

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Publish.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Publish.java
@@ -31,9 +31,10 @@ public class Publish implements IMessage {
     public final Map<String, Object> kwargs;
     public final boolean acknowledge;
     public final boolean excludeMe;
+    public final boolean retain;
 
     public Publish(long request, String topic, List<Object> args, Map<String, Object> kwargs,
-                   boolean acknowledge, boolean excludeMe) {
+                   boolean acknowledge, boolean excludeMe, boolean retain) {
 
         this.request = request;
         this.topic = topic;
@@ -41,6 +42,7 @@ public class Publish implements IMessage {
         this.kwargs = kwargs;
         this.acknowledge = acknowledge;
         this.excludeMe = excludeMe;
+        this.retain = retain;
     }
 
     public static Publish parse(List<Object> wmsg) {
@@ -65,8 +67,9 @@ public class Publish implements IMessage {
 
         boolean acknowledge = (boolean)options.getOrDefault("acknowledge", false);
         boolean excludeMe = (boolean)options.getOrDefault("exclude_me", true);
-
-        return new Publish(request, topic, args, kwargs, acknowledge, excludeMe);
+        boolean retain = (boolean)options.getOrDefault("retain", false);
+        
+        return new Publish(request, topic, args, kwargs, acknowledge, excludeMe, retain);
     }
 
     @Override
@@ -80,6 +83,9 @@ public class Publish implements IMessage {
         }
         if (!excludeMe) {
         	options.put("exclude_me", excludeMe);
+        }
+        if (retain) {
+        	options.put("retain", retain);
         }
         marshaled.add(options);
         marshaled.add(topic);

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/types/EventDetails.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/types/EventDetails.java
@@ -19,9 +19,15 @@ public class EventDetails {
     // The subscription on which this event is delivered to.
     public final Subscription subscription;
 
+    // ID from the original publication request
+    public final long publication;
+    
     // The URI of the topic under the subscription.
     public final String topic;
-
+    
+    // True if the event was retained in the broker
+    public final boolean retained;
+    
     // The WAMP sessionid of the publisher.
     public final long publisherSessionID;
 
@@ -34,10 +40,13 @@ public class EventDetails {
     // The WAMP session on which this event is delivered.
     public final Session session;
 
-    public EventDetails(Subscription subscription, String topic, long publisherSessionID,
+    public EventDetails(Subscription subscription, long publication, String topic, 
+                             boolean retained, long publisherSessionID,
                              String publisherAuthID, String publisherAuthRole, Session session) {
         this.subscription = subscription;
+        this.publication = publication;
         this.topic = topic;
+        this.retained = retained;
         this.publisherSessionID = publisherSessionID;
         this.publisherAuthID = publisherAuthID;
         this.publisherAuthRole = publisherAuthRole;

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/types/PublishOptions.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/types/PublishOptions.java
@@ -14,9 +14,15 @@ package io.crossbar.autobahn.wamp.types;
 public class PublishOptions {
     public final boolean acknowledge;
     public final boolean excludeMe;
+    public final boolean retain;
 
     public PublishOptions(boolean acknowledge, boolean excludeMe) {
+    	this(acknowledge, excludeMe, false);
+    }
+    
+    public PublishOptions(boolean acknowledge, boolean excludeMe, boolean retain) {
         this.acknowledge = acknowledge;
         this.excludeMe = excludeMe;
+        this.retain = retain;
     }
 }


### PR DESCRIPTION
Subscribe already supports the `get_retained` options but to fully support Event Retention two more options are needed: `Publish.Options.retain` and `Event.Details.retained`

[Event Retention Specification](https://github.com/wamp-proto/wamp-proto/blob/da34d9bd833beeb6f9cc8bc89faf8138d710aa78/rfc/text/advanced/ap_pubsub_event_retention.md)

When a client subscribes to a wildcard or prefix topic the broker sends back the full topic name in the property `Event.Details.topic`.