### PR TITLE
Make example client universal

### DIFF
--- a/autobahn/build.gradle
+++ b/autobahn/build.gradle
@@ -35,7 +35,7 @@ if (plugins.hasPlugin(project.PLUGIN_ANDROID_LIB)) {
         main {
             java {
                 include 'io/crossbar/autobahn/wamp/**'
-                exclude 'io/crossbar/autobahn/wamp/transports/AutobahnTransport.java'
+                exclude 'io/crossbar/autobahn/wamp/transports/AndroidWebSocket.java'
             }
         }
     }

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/transports/AndroidWebSocket.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/transports/AndroidWebSocket.java
@@ -24,9 +24,9 @@ import io.crossbar.autobahn.websocket.WebSocketConnection;
 import io.crossbar.autobahn.websocket.WebSocketConnectionHandler;
 import io.crossbar.autobahn.websocket.types.ConnectionResponse;
 
-public class AutobahnTransport implements ITransport {
+public class AndroidWebSocket implements ITransport {
 
-    private static final Logger LOGGER = Logger.getLogger(AutobahnTransport.class.getName());
+    private static final Logger LOGGER = Logger.getLogger(AndroidWebSocket.class.getName());
     private static final String[] SERIALIZERS_DEFAULT = new String[] {
             CBORSerializer.NAME, MessagePackSerializer.NAME, JSONSerializer.NAME};
 
@@ -36,12 +36,12 @@ public class AutobahnTransport implements ITransport {
     private List<String> mSerializers;
     private ISerializer mSerializer;
 
-    public AutobahnTransport(String uri) {
+    public AndroidWebSocket(String uri) {
         mUri = uri;
         mConnection = new WebSocketConnection();
     }
 
-    public AutobahnTransport(String uri, List<String> serializers) {
+    public AndroidWebSocket(String uri, List<String> serializers) {
         this(uri);
         mSerializers = serializers;
     }
@@ -75,7 +75,7 @@ public class AutobahnTransport implements ITransport {
             @Override
             public void onOpen() {
                 try {
-                    transportHandler.onConnect(AutobahnTransport.this, mSerializer);
+                    transportHandler.onConnect(AndroidWebSocket.this, mSerializer);
                 } catch (Exception e) {
                     e.printStackTrace();
                 }

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/transports/NettyTransport.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/transports/NettyTransport.java
@@ -14,7 +14,6 @@ package io.crossbar.autobahn.wamp.transports;
 import java.net.URI;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 
@@ -80,25 +79,10 @@ public class NettyTransport implements ITransport {
         mOptions = options;
     }
 
-    public NettyTransport(String uri, ExecutorService executor) {
-        this(uri);
-        mExecutor = executor;
-    }
-
-    public NettyTransport(String uri, List<String> serializers, ExecutorService executor) {
-        this(uri);
-        mExecutor = executor;
+    public NettyTransport(String uri, List<String> serializers, WebSocketOptions options) {
+        mUri = uri;
         mSerializers = serializers;
-    }
-
-    public NettyTransport(String uri, ExecutorService executor, WebSocketOptions options) {
-        this(uri);
-        mExecutor = executor;
         mOptions = options;
-    }
-
-    private ExecutorService getExecutor() {
-        return mExecutor == null ? ForkJoinPool.commonPool() : mExecutor;
     }
 
     private WebSocketOptions getOptions() {

--- a/autobahn/src/main/java/io/crossbar/autobahn/websocket/WebSocketReader.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/websocket/WebSocketReader.java
@@ -86,7 +86,6 @@ class WebSocketReader extends Thread {
     private static class FrameHeader {
         public int mOpcode;
         public boolean mFin;
-        @SuppressWarnings("unused")
         public int mReserved;
         public int mHeaderLen;
         public int mPayloadLen;

--- a/demo-gallery/build.gradle
+++ b/demo-gallery/build.gradle
@@ -30,6 +30,7 @@ if (plugins.hasPlugin(project.PLUGIN_ANDROID_APP)) {
             main {
                 java {
                     include 'io/crossbar/autobahn/demogallery/android/**'
+                    include 'io/crossbar/autobahn/demogallery/ExampleClient.java'
                 }
             }
         }
@@ -50,6 +51,7 @@ if (plugins.hasPlugin(project.PLUGIN_ANDROID_APP)) {
         main {
             java {
                 include 'io/crossbar/autobahn/demogallery/netty/**'
+                include 'io/crossbar/autobahn/demogallery/ExampleClient.java'
             }
         }
     }

--- a/demo-gallery/src/main/java/io/crossbar/autobahn/demogallery/ExampleClient.java
+++ b/demo-gallery/src/main/java/io/crossbar/autobahn/demogallery/ExampleClient.java
@@ -60,12 +60,12 @@ public class ExampleClient {
     // Convenience method to dynamically return a transport based on the underlying platform.
     // No rocket science here.
     // Could easily replace all the underlying code with just
-    // return new AutobahnTransport(webSocketURL);
+    // return new AndroidWebSocket(webSocketURL);
     // If the underlying platform is known upfront.
     private ITransport selectTransport(String webSocketURL) throws Exception {
         Class<?> transportClass;
         if (Objects.equals(System.getProperty("java.vendor"), "The Android Project")) {
-            transportClass = Class.forName("io.crossbar.autobahn.wamp.transports.AutobahnTransport");
+            transportClass = Class.forName("io.crossbar.autobahn.wamp.transports.AndroidWebSocket");
         } else {
             transportClass = Class.forName("io.crossbar.autobahn.wamp.transports.NettyTransport");
         }

--- a/demo-gallery/src/main/java/io/crossbar/autobahn/demogallery/android/MainActivity.java
+++ b/demo-gallery/src/main/java/io/crossbar/autobahn/demogallery/android/MainActivity.java
@@ -16,10 +16,7 @@ import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.view.View;
 
-import java.util.concurrent.CompletableFuture;
-
 import io.crossbar.autobahn.demogallery.R;
-import io.crossbar.autobahn.wamp.types.ExitInfo;
 
 
 public class MainActivity extends AppCompatActivity implements View.OnClickListener {
@@ -28,9 +25,6 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
-        ExampleClient client = new ExampleClient();
-        CompletableFuture<ExitInfo> e = client.main("ws://192.168.1.6:8080/ws", "realm1");
-        e.thenAccept(System.out::println);
     }
 
     @Override


### PR DESCRIPTION
- NettyTransport no longer takes a custom executor as that's unneeded
- Move example client one directory up and enable for both Android and Netty (it dynamically selects which transport to use based on the platform).
- Rename AutobahnTransport to AndroidWebSocket

side note: We have already done a release of Netty otherwise, it might have made more sense to name NettyTransport as NettyWebSocket.