### PR TITLE
Reduce java8 usage internally

### DIFF
--- a/autobahn/build.gradle
+++ b/autobahn/build.gradle
@@ -6,7 +6,7 @@ if (plugins.hasPlugin(project.PLUGIN_ANDROID_LIB)) {
         buildToolsVersion '26.0.1'
 
         defaultConfig {
-            minSdkVersion 24
+            minSdkVersion 15
             targetSdkVersion 26
         }
 

--- a/autobahn/build.gradle
+++ b/autobahn/build.gradle
@@ -6,7 +6,7 @@ if (plugins.hasPlugin(project.PLUGIN_ANDROID_LIB)) {
         buildToolsVersion '26.0.1'
 
         defaultConfig {
-            minSdkVersion 15
+            minSdkVersion 24
             targetSdkVersion 26
         }
 
@@ -64,4 +64,5 @@ dependencies {
         runtime 'com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.8.8'
         runtime 'org.msgpack:jackson-dataformat-msgpack:0.8.13'
     }
+    // compile 'net.sourceforge.streamsupport:streamsupport-cfuture:1.5.6'
 }

--- a/autobahn/build.gradle
+++ b/autobahn/build.gradle
@@ -64,5 +64,5 @@ dependencies {
         runtime 'com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.8.8'
         runtime 'org.msgpack:jackson-dataformat-msgpack:0.8.13'
     }
-    // compile 'net.sourceforge.streamsupport:streamsupport-cfuture:1.5.6'
+    // implementation 'net.sourceforge.streamsupport:streamsupport-cfuture:1.5.6'
 }

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/Session.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/Session.java
@@ -76,6 +76,7 @@ import io.crossbar.autobahn.wamp.types.Subscription;
 import io.crossbar.autobahn.wamp.utils.IDGenerator;
 
 import static io.crossbar.autobahn.wamp.messages.MessageMap.MESSAGE_TYPE_MAP;
+import static io.crossbar.autobahn.wamp.utils.Shortcuts.getOrDefault;
 
 
 public class Session implements ISession, ITransportHandler {
@@ -246,7 +247,7 @@ public class Session implements ISession, ITransportHandler {
             // Now that we have an active session handle all incoming messages here.
             if (message instanceof Result) {
                 Result msg = (Result) message;
-                CallRequest request = mCallRequests.getOrDefault(msg.request, null);
+                CallRequest request = getOrDefault(mCallRequests, msg.request, null);
                 if (request != null) {
                     mCallRequests.remove(msg.request);
 
@@ -266,7 +267,7 @@ public class Session implements ISession, ITransportHandler {
                 }
             } else if (message instanceof Subscribed) {
                 Subscribed msg = (Subscribed) message;
-                SubscribeRequest request = mSubscribeRequests.getOrDefault(msg.request, null);
+                SubscribeRequest request = getOrDefault(mSubscribeRequests, msg.request, null);
                 if (request != null) {
                     mSubscribeRequests.remove(msg.request);
                     if (!mSubscriptions.containsKey(msg.subscription)) {
@@ -281,7 +282,7 @@ public class Session implements ISession, ITransportHandler {
                 }
             } else if (message instanceof Event) {
                 Event msg = (Event) message;
-                List<Subscription> subscriptions = mSubscriptions.getOrDefault(msg.subscription, null);
+                List<Subscription> subscriptions = getOrDefault(mSubscriptions, msg.subscription, null);
                 if (subscriptions == null) {
                     throw new ProtocolError(String.format(
                             "EVENT received for non-subscribed subscription ID %s", msg.subscription));
@@ -333,7 +334,7 @@ public class Session implements ISession, ITransportHandler {
                 combineFutures(futures);
             } else if (message instanceof Published) {
                 Published msg = (Published) message;
-                PublishRequest request = mPublishRequests.getOrDefault(msg.request, null);
+                PublishRequest request = getOrDefault(mPublishRequests, msg.request, null);
                 if (request != null) {
                     mPublishRequests.remove(msg.request);
                     Publication publication = new Publication(msg.publication);
@@ -344,7 +345,7 @@ public class Session implements ISession, ITransportHandler {
                 }
             } else if (message instanceof Registered) {
                 Registered msg = (Registered) message;
-                RegisterRequest request = mRegisterRequest.getOrDefault(msg.request, null);
+                RegisterRequest request = getOrDefault(mRegisterRequest, msg.request, null);
                 if (request != null) {
                     mRegisterRequest.remove(msg.request);
                     Registration registration = new Registration(
@@ -357,7 +358,7 @@ public class Session implements ISession, ITransportHandler {
                 }
             } else if (message instanceof Invocation) {
                 Invocation msg = (Invocation) message;
-                Registration registration = mRegistrations.getOrDefault(msg.registration, null);
+                Registration registration = getOrDefault(mRegistrations, msg.registration, null);
 
                 if (registration != null) {
 

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Abort.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Abort.java
@@ -19,6 +19,8 @@ import java.util.Map;
 import io.crossbar.autobahn.wamp.interfaces.IMessage;
 import io.crossbar.autobahn.wamp.utils.MessageUtil;
 
+import static io.crossbar.autobahn.wamp.utils.Shortcuts.getOrDefault;
+
 public class Abort implements IMessage {
 
     public static final int MESSAGE_TYPE = 3;
@@ -35,10 +37,7 @@ public class Abort implements IMessage {
         MessageUtil.validateMessage(wmsg, MESSAGE_TYPE, "ABORT", 3);
 
         Map<String, Object> details = (Map<String, Object>) wmsg.get(1);
-        String message = null;
-        if (details.containsKey("message")) {
-            message = (String) details.get("message");
-        }
+        String message = getOrDefault(details, "message", null);
         String reason = (String) wmsg.get(2);
 
         return new Abort(reason, message);

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Call.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Call.java
@@ -21,6 +21,8 @@ import io.crossbar.autobahn.wamp.exceptions.ProtocolError;
 import io.crossbar.autobahn.wamp.interfaces.IMessage;
 import io.crossbar.autobahn.wamp.utils.MessageUtil;
 
+import static io.crossbar.autobahn.wamp.utils.Shortcuts.getOrDefault;
+
 public class Call implements IMessage {
 
     public static final int MESSAGE_TYPE = 48;
@@ -65,7 +67,7 @@ public class Call implements IMessage {
             kwargs = (Map<String, Object>) wmsg.get(5);
         }
 
-        int timeout = (int) options.getOrDefault("timeout", TIMEOUT_DEFAULT);
+        int timeout = getOrDefault(options, "timeout", TIMEOUT_DEFAULT);
 
         return new Call(request, procedure, args, kwargs, timeout);
     }

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Cancel.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Cancel.java
@@ -21,6 +21,8 @@ import java.util.Objects;
 import io.crossbar.autobahn.wamp.interfaces.IMessage;
 import io.crossbar.autobahn.wamp.utils.MessageUtil;
 
+import static io.crossbar.autobahn.wamp.utils.Shortcuts.getOrDefault;
+
 public class Cancel implements IMessage {
 
     public static final int MESSAGE_TYPE = 49;
@@ -35,7 +37,7 @@ public class Cancel implements IMessage {
     public Cancel(long request, String mode) {
         this.request = request;
         if (mode != null) {
-            if (!Objects.equals(mode, SKIP) && !Objects.equals(mode, ABORT) && !Objects.equals(mode, KILL)) {
+            if (!mode.equals(SKIP) && !mode.equals(ABORT) && !mode.equals(KILL)) {
                 throw new IllegalArgumentException("mode must either be skip, abort or kill");
             }
         }
@@ -46,7 +48,7 @@ public class Cancel implements IMessage {
         MessageUtil.validateMessage(wmsg, MESSAGE_TYPE, "CANCEL", 3);
         long request = MessageUtil.parseRequestID(wmsg.get(1));
         Map<String, Object> options = (Map<String, Object>) wmsg.get(2);
-        String mode = (String) options.getOrDefault("mode", null);
+        String mode = getOrDefault(options, "mode", null);
         return new Cancel(request, mode);
     }
 

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Event.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Event.java
@@ -21,6 +21,8 @@ import io.crossbar.autobahn.wamp.exceptions.ProtocolError;
 import io.crossbar.autobahn.wamp.interfaces.IMessage;
 import io.crossbar.autobahn.wamp.utils.MessageUtil;
 
+import static io.crossbar.autobahn.wamp.utils.Shortcuts.getOrDefault;
+
 public class Event implements IMessage {
 
     public static final int MESSAGE_TYPE = 36;
@@ -48,7 +50,7 @@ public class Event implements IMessage {
 
         Map<String, Object> details = (Map<String, Object>) wmsg.get(3);
         String topic = (String)details.get("topic");
-        boolean retained = (boolean)details.getOrDefault("retained", false);
+        boolean retained = getOrDefault(details, "retained", false);
 
         List<Object> args = null;
         if (wmsg.size() > 4) {

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Interrupt.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Interrupt.java
@@ -22,6 +22,8 @@ import io.crossbar.autobahn.wamp.exceptions.ProtocolError;
 import io.crossbar.autobahn.wamp.interfaces.IMessage;
 import io.crossbar.autobahn.wamp.utils.MessageUtil;
 
+import static io.crossbar.autobahn.wamp.utils.Shortcuts.getOrDefault;
+
 public class Interrupt implements IMessage {
 
     public static final int MESSAGE_TYPE = 69;
@@ -42,9 +44,9 @@ public class Interrupt implements IMessage {
 
         long request = MessageUtil.parseRequestID(wmsg.get(1));
         Map<String, Object> options = (Map<String, Object>) wmsg.get(2);
-        String mode = (String) options.getOrDefault("mode", null);
+        String mode = getOrDefault(options, "mode", null);
         if (mode != null) {
-            if (!Objects.equals(mode, ABORT) && !Objects.equals(mode, KILL)) {
+            if (!mode.equals(ABORT) && !mode.equals(KILL)) {
                 throw new ProtocolError(String.format("invalid value %s for 'mode' option in INTERRUPT", mode));
             }
         }

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Publish.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Publish.java
@@ -21,6 +21,8 @@ import io.crossbar.autobahn.wamp.exceptions.ProtocolError;
 import io.crossbar.autobahn.wamp.interfaces.IMessage;
 import io.crossbar.autobahn.wamp.utils.MessageUtil;
 
+import static io.crossbar.autobahn.wamp.utils.Shortcuts.getOrDefault;
+
 public class Publish implements IMessage {
 
     public static final int MESSAGE_TYPE = 16;
@@ -65,9 +67,9 @@ public class Publish implements IMessage {
             kwargs = (Map<String, Object>) wmsg.get(5);
         }
 
-        boolean acknowledge = (boolean)options.getOrDefault("acknowledge", false);
-        boolean excludeMe = (boolean)options.getOrDefault("exclude_me", true);
-        boolean retain = (boolean)options.getOrDefault("retain", false);
+        boolean acknowledge = getOrDefault(options, "acknowledge", false);
+        boolean excludeMe = getOrDefault(options, "exclude_me", true);
+        boolean retain = getOrDefault(options, "retain", false);
 
         return new Publish(request, topic, args, kwargs, acknowledge, excludeMe, retain);
     }

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Register.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Register.java
@@ -45,8 +45,8 @@ public class Register implements IMessage {
         this.request = request;
         this.procedure = procedure;
         if (match != null) {
-            if (!Objects.equals(match, MATCH_EXACT) && !Objects.equals(match, MATCH_PREFIX) &&
-                    !Objects.equals(match, MATCH_WILDCARD)) {
+            if (!match.equals(MATCH_EXACT) && !match.equals(MATCH_PREFIX) &&
+                    !match.equals(MATCH_WILDCARD)) {
                 throw new IllegalArgumentException("match must be one of exact, prefix or wildcard.");
             }
             this.match = match;
@@ -54,9 +54,9 @@ public class Register implements IMessage {
             this.match = null;
         }
         if (invoke != null) {
-            if (!Objects.equals(invoke, INVOKE_SINGLE) && !Objects.equals(invoke, INVOKE_FIRST) &&
-                    !Objects.equals(invoke, INVOKE_LAST) && !Objects.equals(invoke, INVOKE_ROUNDROBIN) &&
-                    !Objects.equals(invoke, INVOKE_RANDOM) && !Objects.equals(invoke, INVOKE_ALL)) {
+            if (!invoke.equals(INVOKE_SINGLE) && !invoke.equals(INVOKE_FIRST) &&
+                    !invoke.equals(INVOKE_LAST) && !invoke.equals(INVOKE_ROUNDROBIN) &&
+                    !invoke.equals(INVOKE_RANDOM) && !invoke.equals(INVOKE_ALL)) {
                 throw new IllegalArgumentException(
                         "invoke must be one of single, first, last, roundrobin, random or all.");
             }
@@ -74,18 +74,18 @@ public class Register implements IMessage {
         String match = null;
         if (options.containsKey("match")) {
             match = (String) options.get("match");
-            if (!Objects.equals(match, MATCH_EXACT) && !Objects.equals(match, MATCH_PREFIX) &&
-                    !Objects.equals(match, MATCH_WILDCARD)) {
+            if (!match.equals(MATCH_EXACT) && !match.equals(MATCH_PREFIX) &&
+                    !match.equals(MATCH_WILDCARD)) {
                 throw new ProtocolError("match must be one of exact, prefix or wildcard.");
             }
         }
         String invoke = null;
         if (options.containsKey("invoke")) {
             invoke = (String) options.get("invoke");
-            if (!Objects.equals(invoke, INVOKE_SINGLE) && !Objects.equals(invoke, INVOKE_FIRST) &&
-                    !Objects.equals(invoke, INVOKE_LAST) && !Objects.equals(invoke, INVOKE_ROUNDROBIN) &&
-                    !Objects.equals(invoke, INVOKE_RANDOM) && !Objects.equals(invoke, INVOKE_ALL)) {
-                throw new ProtocolError(
+            if (!invoke.equals(INVOKE_SINGLE) && !invoke.equals(INVOKE_FIRST) &&
+                    !invoke.equals(INVOKE_LAST) && !invoke.equals(INVOKE_ROUNDROBIN) &&
+                    !invoke.equals(INVOKE_RANDOM) && !invoke.equals(INVOKE_ALL)) {
+                throw new IllegalArgumentException(
                         "invoke must be one of single, first, last, roundrobin, random or all.");
             }
         }
@@ -99,10 +99,10 @@ public class Register implements IMessage {
         marshaled.add(MESSAGE_TYPE);
         marshaled.add(request);
         Map<String, Object> options = new HashMap<>();
-        if (match != null && !Objects.equals(match, MATCH_EXACT)) {
+        if (match != null && !match.equals(MATCH_EXACT)) {
             options.put("match", match);
         }
-        if (invoke != null && !Objects.equals(invoke, INVOKE_SINGLE)) {
+        if (invoke != null && !invoke.equals(INVOKE_SINGLE)) {
             options.put("invoke", invoke);
         }
         marshaled.add(options);

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Subscribe.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Subscribe.java
@@ -22,6 +22,8 @@ import io.crossbar.autobahn.wamp.interfaces.IMessage;
 import io.crossbar.autobahn.wamp.types.SubscribeOptions;
 import io.crossbar.autobahn.wamp.utils.MessageUtil;
 
+import static io.crossbar.autobahn.wamp.utils.Shortcuts.getOrDefault;
+
 public class Subscribe implements IMessage {
 
     public static final int MESSAGE_TYPE = 32;
@@ -40,8 +42,8 @@ public class Subscribe implements IMessage {
         this.topic = topic;
         if (options != null) {
             if (options.match != null) {
-                if (!Objects.equals(options.match, MATCH_EXACT) && !Objects.equals(options.match, MATCH_PREFIX) &&
-                        !Objects.equals(options.match, MATCH_WILDCARD)) {
+                if (!options.match.equals(MATCH_EXACT) && !options.match.equals(MATCH_PREFIX) &&
+                        !options.match.equals(MATCH_EXACT)) {
                     throw new IllegalArgumentException("match must be one of exact, prefix or wildcard.");
                 }
             }
@@ -62,13 +64,12 @@ public class Subscribe implements IMessage {
         String match = null;
         if (options.containsKey("match")) {
             match = (String) options.get("match");
-            if (!Objects.equals(match, MATCH_EXACT) && !Objects.equals(match, MATCH_PREFIX) &&
-                    !Objects.equals(match, MATCH_WILDCARD)) {
+            if (!match.equals(MATCH_EXACT) && !match.equals(MATCH_PREFIX) &&
+                    !match.equals(MATCH_EXACT)) {
                 throw new ProtocolError("match must be one of exact, prefix or wildcard.");
             }
         }
-        
-        boolean getRetained = (boolean)options.getOrDefault("get_retained", false);
+        boolean getRetained = getOrDefault(options, "get_retained", false);
 
         String topic = (String) wmsg.get(3);
         SubscribeOptions opt = new SubscribeOptions(match, true, getRetained);
@@ -81,7 +82,7 @@ public class Subscribe implements IMessage {
         marshaled.add(MESSAGE_TYPE);
         marshaled.add(request);
         Map<String, Object> extra = new HashMap<>();
-        if (match != null && !Objects.equals(match, MATCH_EXACT)) {
+        if (match != null && !match.equals(MATCH_EXACT)) {
         	 extra.put("match", match);
         }
         if (getRetained) {

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Unregistered.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Unregistered.java
@@ -19,6 +19,8 @@ import java.util.Map;
 import io.crossbar.autobahn.wamp.interfaces.IMessage;
 import io.crossbar.autobahn.wamp.utils.MessageUtil;
 
+import static io.crossbar.autobahn.wamp.utils.Shortcuts.getOrDefault;
+
 public class Unregistered implements IMessage {
 
     public static final int MESSAGE_TYPE = 67;
@@ -41,8 +43,8 @@ public class Unregistered implements IMessage {
         String reason = null;
         if (wmsg.size() > 2) {
             Map<String, Object> details = (Map<String, Object>) wmsg.get(2);
-            registration = (long) details.getOrDefault("registration", registration);
-            reason = (String) details.getOrDefault("reason", reason);
+            registration = getOrDefault(details, "registration", registration);
+            reason = getOrDefault(details, "reason", reason);
         }
 
         return new Unregistered(MessageUtil.parseRequestID(wmsg.get(1)), registration, reason);

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/transports/NettyTransport.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/transports/NettyTransport.java
@@ -19,6 +19,7 @@ import java.util.logging.Logger;
 
 import javax.net.ssl.SSLException;
 
+import io.crossbar.autobahn.wamp.interfaces.ISerializer;
 import io.crossbar.autobahn.wamp.interfaces.ITransport;
 import io.crossbar.autobahn.wamp.interfaces.ITransportHandler;
 import io.crossbar.autobahn.wamp.serializers.CBORSerializer;
@@ -113,7 +114,9 @@ public class NettyTransport implements ITransport {
     private String getSerializers() {
         if (mSerializers != null) {
             StringBuilder result = new StringBuilder();
-            mSerializers.forEach(s -> result.append(s).append(","));
+            for (String serializer: mSerializers) {
+                result.append(serializer).append(",");
+            }
             return result.toString();
         }
         return SERIALIZERS_DEFAULT;

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/utils/Shortcuts.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/utils/Shortcuts.java
@@ -1,0 +1,12 @@
+package io.crossbar.autobahn.wamp.utils;
+
+import java.util.Map;
+
+public class Shortcuts {
+    public static <T> T getOrDefault(Map<?, ?> obj, Object key, T default_value) {
+        if (obj.containsKey(key)) {
+            return (T) obj.get(key);
+        }
+        return default_value;
+    }
+}

--- a/autobahn/src/main/java/io/crossbar/autobahn/websocket/WebSocketConnection.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/websocket/WebSocketConnection.java
@@ -444,6 +444,13 @@ public class WebSocketConnection implements IWebSocket {
         onCloseCalled = false;
     }
 
+    private <T> T getOrDefault(Map<?, ?> obj, Object key, T default_value) {
+        if (obj.containsKey(key)) {
+            return (T) obj.get(key);
+        }
+        return default_value;
+    }
+
 
     /**
      * Create master message handler.
@@ -537,9 +544,9 @@ public class WebSocketConnection implements IWebSocket {
 
                     if (serverHandshake.mSuccess) {
                         if (mWsHandler != null) {
-                            mWsHandler.onConnect(new ConnectionResponse(
-                                    serverHandshake.headers.getOrDefault(
-                                            "Sec-WebSocket-Protocol", null)));
+                            String protocol = getOrDefault(serverHandshake.headers,
+                                    "Sec-WebSocket-Protocol", null);
+                            mWsHandler.onConnect(new ConnectionResponse(protocol));
                             mWsHandler.onOpen();
                             if (DEBUG) Log.d(TAG, "onOpen() called, ready to rock.");
                         } else {

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ buildscript {
     // Netty build does not need android dependencies.
     if (project.properties.get('buildPlatform', 'android') == 'android') {
         dependencies {
-            classpath 'com.android.tools.build:gradle:3.0.0-beta5'
+            classpath 'com.android.tools.build:gradle:3.0.0-beta6'
         }
     }
 }

--- a/demo-gallery/build.gradle
+++ b/demo-gallery/build.gradle
@@ -31,6 +31,7 @@ if (plugins.hasPlugin(project.PLUGIN_ANDROID_APP)) {
                 java {
                     include 'io/crossbar/autobahn/demogallery/android/**'
                     include 'io/crossbar/autobahn/demogallery/ExampleClient.java'
+                    exclude 'io/crossbar/autobahn/demogallery/netty/**'
                 }
             }
         }
@@ -41,6 +42,7 @@ if (plugins.hasPlugin(project.PLUGIN_ANDROID_APP)) {
         implementation project(path: ':autobahn')
         implementation 'com.android.support:appcompat-v7:26.0.2'
         implementation 'com.fasterxml.jackson.core:jackson-core:2.8.8'
+        // compile 'net.sourceforge.streamsupport:streamsupport-cfuture:1.5.6'
     }
 } else {
     mainClassName = 'io.crossbar.autobahn.demogallery.netty.Main'
@@ -52,6 +54,7 @@ if (plugins.hasPlugin(project.PLUGIN_ANDROID_APP)) {
             java {
                 include 'io/crossbar/autobahn/demogallery/netty/**'
                 include 'io/crossbar/autobahn/demogallery/ExampleClient.java'
+                exclude 'io/crossbar/autobahn/demogallery/android/**'
             }
         }
     }

--- a/demo-gallery/build.gradle
+++ b/demo-gallery/build.gradle
@@ -13,7 +13,7 @@ if (plugins.hasPlugin(project.PLUGIN_ANDROID_APP)) {
         }
 
         defaultConfig {
-            minSdkVersion 15
+            minSdkVersion 24
             targetSdkVersion 26
         }
         buildTypes {

--- a/demo-gallery/build.gradle
+++ b/demo-gallery/build.gradle
@@ -42,7 +42,7 @@ if (plugins.hasPlugin(project.PLUGIN_ANDROID_APP)) {
         implementation project(path: ':autobahn')
         implementation 'com.android.support:appcompat-v7:26.0.2'
         implementation 'com.fasterxml.jackson.core:jackson-core:2.8.8'
-        // compile 'net.sourceforge.streamsupport:streamsupport-cfuture:1.5.6'
+        // implementation 'net.sourceforge.streamsupport:streamsupport-cfuture:1.5.6'
     }
 } else {
     mainClassName = 'io.crossbar.autobahn.demogallery.netty.Main'

--- a/demo-gallery/build.gradle
+++ b/demo-gallery/build.gradle
@@ -13,7 +13,7 @@ if (plugins.hasPlugin(project.PLUGIN_ANDROID_APP)) {
         }
 
         defaultConfig {
-            minSdkVersion 24
+            minSdkVersion 15
             targetSdkVersion 26
         }
         buildTypes {

--- a/demo-gallery/src/main/java/io/crossbar/autobahn/demogallery/ExampleClient.java
+++ b/demo-gallery/src/main/java/io/crossbar/autobahn/demogallery/ExampleClient.java
@@ -64,7 +64,7 @@ public class ExampleClient {
     // If the underlying platform is known upfront.
     private ITransport selectTransport(String webSocketURL) throws Exception {
         Class<?> transportClass;
-        if (Objects.equals(System.getProperty("java.vendor"), "The Android Project")) {
+        if (System.getProperty("java.vendor").equals("The Android Project")) {
             transportClass = Class.forName("io.crossbar.autobahn.wamp.transports.AndroidWebSocket");
         } else {
             transportClass = Class.forName("io.crossbar.autobahn.wamp.transports.NettyTransport");

--- a/docker/Dockerfile.netty
+++ b/docker/Dockerfile.netty
@@ -21,7 +21,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 USER root
 
 ENV DEBIAN_FRONTEND noninteractive
-ENV GRADLE_VERSION 4.0
+ENV GRADLE_VERSION 4.1
 
 WORKDIR /workspace
 


### PR DESCRIPTION
This branch reduces the use of java8-exclusive features internally, that in turns will allow us to support older versions of Android __very__ easily by just using a shell script.

- Replaces all occurrences of Objects.equals(string1, string2) with string1.equals(string2)
- Replaces all occurrences of Map.getOrDefault() with a custom, backwards-compatible getOrDefault()
- Replaces all occurrences of List.forEach() with old-school for each loop.

No API changes, everything happened in the background.