### PR TITLE
Maven and JCenter config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,8 @@
 BUILD_DATE=$(shell date -u +"%Y-%m-%d")
-AUTOBAHN_JAVA_VERSION='17.9.1'
+AUTOBAHN_JAVA_VERSION='17.10.1'
 AUTOBAHN_JAVA_VCS_REF='unknown'
 
 #export AUTOBAHN_TESTSUITE_VCS_REF=`git --git-dir="../autobahn-testsuite/.git" rev-list -n 1 v${AUTOBAHN_TESTSUITE_VERSION} --abbrev-commit`
-#export BUILD_DATE=`date -u +"%Y-%m-%d"`
-
-#git rev-list -n 1 v${AUTOBAHN_JAVA_VERSION} --abbrev-commit
-
 
 #
 # Demos
@@ -24,12 +20,11 @@ python:
 		python -u /test/test_component.py
 
 java:
-	docker run -it --rm \
-		--link crossbar \
+	docker run \
+		-it --rm --link crossbar \
 		-v ${shell pwd}:/workspace \
 		crossbario/autobahn-java:netty \
 			/bin/bash -c "gradle installDist -PbuildPlatform=netty && DEMO_GALLERY_OPTS="-DlogLevel=INFO" demo-gallery/build/install/demo-gallery/bin/demo-gallery ws://crossbar:8080/ws"
-
 
 #
 # Build
@@ -44,7 +39,7 @@ build_autobahn:
 # Toolchain
 #
 build_toolchain:
-	time docker build \
+	docker build \
 		--build-arg BUILD_DATE=${BUILD_DATE} \
 		--build-arg AUTOBAHN_JAVA_VCS_REF=${AUTOBAHN_JAVA_VCS_REF} \
 		--build-arg AUTOBAHN_JAVA_VERSION=${AUTOBAHN_JAVA_VERSION} \
@@ -57,6 +52,16 @@ publish_toolchain:
 	docker push crossbario/autobahn-java
 	docker push crossbario/autobahn-java:netty
 	docker push crossbario/autobahn-java:netty-${AUTOBAHN_JAVA_VERSION}
+
+#
+# Publish the libraries.
+#
+
+publish_android:
+	AUTOBAHN_BUILD_VERSION=${AUTOBAHN_JAVA_VERSION} gradle bintrayUpload -PbuildPlatform=android
+
+publish_netty:
+	AUTOBAHN_BUILD_VERSION=${AUTOBAHN_JAVA_VERSION} gradle bintrayUpload -PbuildPlatform=netty
 
 check_toolchain:
 	docker run -it --rm crossbario/autobahn-java:netty /bin/bash -c "ls -la /autobahn && du -hs /autobahn"

--- a/autobahn/build.gradle
+++ b/autobahn/build.gradle
@@ -1,74 +1,19 @@
 apply plugin: project.PLATFORM == project.PLATFORM_NETTY ? project.PLUGIN_JAVA_LIB: project.PLUGIN_ANDROID_LIB
+apply plugin: project.PLATFORM == project.PLATFORM_NETTY ? 'maven-publish': 'com.github.dcendents.android-maven'
+apply plugin: 'com.jfrog.bintray'
 
-ext {
-    bintrayRepo = 'maven'
-    bintrayName = 'autobahn'
+def ARTIFACT_ANDROID = 'autobahn-android'
+def ARTIFACT_JAVA = 'autobahn-java'
 
-    publishedGroupId = 'io.crossbar'
-    libraryName = 'autobahn'
-    artifact = 'autobahn'
-
-    libraryDescription = 'WebSocket and WAMP in Java'
-
-    siteUrl = 'https://github.com/crossbario/autobahn-java'
-    gitUrl = 'https://github.com/crossbario/autobahn-java.git'
-
-    libraryVersion = '17.9.2'
-
-    developerId = 'crossbario'
-    developerName = 'crossbario'
-    developerEmail = 'support@crossbario.com'
-
-    licenseName = 'MIT License'
-    licenseUrl = 'http://opensource.org/licenses/MIT'
-    allLicenses = ["MIT"]
-}
-
-if (plugins.hasPlugin(project.PLUGIN_ANDROID_LIB)) {
-    android {
-        compileSdkVersion 26
-        buildToolsVersion '26.0.1'
-
-        defaultConfig {
-            minSdkVersion 24
-            targetSdkVersion 26
-        }
-
-        buildTypes {
-            release {
-                minifyEnabled false
-                proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
-            }
-        }
-
-        sourceSets {
-            main {
-                java {
-                    exclude 'io/crossbar/autobahn/wamp/transports/Netty*'
-                }
-            }
-        }
-
-        compileOptions {
-            sourceCompatibility JavaVersion.VERSION_1_8
-            targetCompatibility JavaVersion.VERSION_1_8
-        }
-    }
-} else {
-    sourceSets {
-        main {
-            java {
-                exclude 'io/crossbar/autobahn/wamp/transports/AndroidWebSocket.java'
-                exclude 'io/crossbar/autobahn/websocket'
-            }
-        }
-    }
-    jar {
-        version = project.properties.get("buildVersion", "")
-    }
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-}
+def developerId = 'crossbario'
+def developerName = 'crossbario'
+def developerEmail = 'support@crossbario.com'
+def groupID = 'io.crossbar.autobahn'
+def gitUrl = 'https://github.com/crossbario/autobahn-java.git'
+def licenseName = 'MIT'
+def licenseUrl = 'https://opensource.org/licenses/MIT'
+def relVersion = project.properties.get("buildVersion", "17.10.1")
+def siteUrl = 'https://github.com/crossbario/autobahn-java'
 
 dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-core:2.8.8'
@@ -83,5 +28,151 @@ dependencies {
     }
 }
 
-//apply from: 'https://raw.githubusercontent.com/nuuneoi/JCenter/master/installv1.gradle'
-//apply from: 'https://raw.githubusercontent.com/nuuneoi/JCenter/master/bintrayv1.gradle'
+bintray {
+    user = System.getenv('BINTRAY_USERNAME')
+    key = System.getenv('BINTRAY_KEY')
+    if (plugins.hasPlugin(project.PLUGIN_ANDROID_LIB)) {
+        configurations = ['archives']
+    } else {
+        publications = ['mavenJava']
+    }
+    publish = true
+    pkg {
+        repo = 'maven'
+        name = project.PLATFORM == project.PLATFORM_NETTY ? ARTIFACT_JAVA: ARTIFACT_ANDROID
+        licenses = [licenseName]
+        vcsUrl = 'https://github.com/crossbario/autobahn-java.git'
+        version {
+            name = relVersion
+            released = new Date()
+            mavenCentralSync {
+                sync = true
+                user = System.getenv('SONATYPE_USERNAME')
+                password = System.getenv('SONATYPE_PASSWORD')
+            }
+            gpg {
+                sign = true
+                passphrase = System.getenv('BINTRAY_GPG_KEY')
+            }
+        }
+    }
+}
+
+if (plugins.hasPlugin(project.PLUGIN_ANDROID_LIB)) {
+    android {
+        compileSdkVersion 26
+        buildToolsVersion '26.0.1'
+        defaultConfig {
+            minSdkVersion 24
+            targetSdkVersion 26
+        }
+        buildTypes {
+            release {
+                minifyEnabled false
+                proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
+            }
+        }
+        sourceSets {
+            main {
+                java {
+                    exclude 'io/crossbar/autobahn/wamp/transports/Netty*'
+                }
+            }
+        }
+        compileOptions {
+            sourceCompatibility JavaVersion.VERSION_1_8
+            targetCompatibility JavaVersion.VERSION_1_8
+        }
+    }
+    task sourcesJar(type: Jar) {
+        classifier = 'sources'
+        from android.sourceSets.main.java.srcDirs
+    }
+
+    task javadoc(type: Javadoc) {
+        source = android.sourceSets.main.java.srcDirs
+        classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+    }
+    println project.files(android.getBootClasspath().join(File.pathSeparator))
+    project.archivesBaseName = ARTIFACT_ANDROID
+    group = groupID
+    version = relVersion
+    install {
+        repositories.mavenInstaller {
+            // This generates POM.xml with proper parameters
+            pom {
+                project {
+                    packaging 'aar'
+                    groupId groupID
+                    artifactId ARTIFACT_ANDROID
+
+                    // Add your description here
+                    name ARTIFACT_ANDROID
+                    url siteUrl
+
+                    // Set your license
+                    licenses {
+                        license {
+                            name licenseName
+                            url licenseUrl
+                        }
+                    }
+                    developers {
+                        developer {
+                            id developerId
+                            name developerName
+                            email developerEmail
+                        }
+                    }
+                    scm {
+                        connection gitUrl
+                        developerConnection siteUrl
+                        url siteUrl
+                    }
+                }
+            }
+        }
+    }
+} else {
+    publishing {
+        publications {
+            mavenJava(MavenPublication) {
+                groupId groupID
+                artifactId ARTIFACT_JAVA
+                version relVersion
+
+                from components.java
+                artifact sourcesJar
+                artifact javadocJar
+            }
+        }
+    }
+    task sourcesJar(type: Jar, dependsOn: classes) {
+        classifier = 'sources'
+        from sourceSets.main.allSource
+    }
+    task javadocJar(type: Jar, dependsOn: javadoc) {
+        classifier = 'javadoc'
+        from javadoc.destinationDir
+    }
+    artifacts {
+        archives javadocJar
+    }
+    sourceSets {
+        main {
+            java {
+                exclude 'io/crossbar/autobahn/wamp/transports/AndroidWebSocket.java'
+                exclude 'io/crossbar/autobahn/websocket'
+            }
+        }
+    }
+    jar {
+        version = relVersion
+    }
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
+artifacts {
+    archives sourcesJar
+}

--- a/autobahn/build.gradle
+++ b/autobahn/build.gradle
@@ -50,10 +50,10 @@ bintray {
 //                user = System.getenv('SONATYPE_USERNAME')
 //                password = System.getenv('SONATYPE_PASSWORD')
 //            }
-//            gpg {
-//                sign = true
-//                passphrase = System.getenv('BINTRAY_GPG_KEY')
-//            }
+            gpg {
+                sign = true
+                passphrase = System.getenv('BINTRAY_GPG_KEY')
+            }
         }
     }
 }

--- a/autobahn/build.gradle
+++ b/autobahn/build.gradle
@@ -93,7 +93,6 @@ if (plugins.hasPlugin(project.PLUGIN_ANDROID_LIB)) {
         source = android.sourceSets.main.java.srcDirs
         classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
     }
-    println project.files(android.getBootClasspath().join(File.pathSeparator))
     project.archivesBaseName = ARTIFACT_ANDROID
     group = groupID
     version = relVersion

--- a/autobahn/build.gradle
+++ b/autobahn/build.gradle
@@ -12,7 +12,7 @@ def groupID = 'io.crossbar.autobahn'
 def gitUrl = 'https://github.com/crossbario/autobahn-java.git'
 def licenseName = 'MIT'
 def licenseUrl = 'https://opensource.org/licenses/MIT'
-def relVersion = project.properties.get("buildVersion", "17.10.1")
+def relVersion = System.getenv().containsKey('AUTOBAHN_BUILD_VERSION') ? System.getenv('AUTOBAHN_BUILD_VERSION'): '17.10.1'
 def siteUrl = 'https://github.com/crossbario/autobahn-java'
 
 dependencies {

--- a/autobahn/build.gradle
+++ b/autobahn/build.gradle
@@ -29,7 +29,7 @@ dependencies {
 }
 
 bintray {
-    user = System.getenv('BINTRAY_USERNAME')
+    user = System.getenv('BINTRAY_USER')
     key = System.getenv('BINTRAY_KEY')
     if (plugins.hasPlugin(project.PLUGIN_ANDROID_LIB)) {
         configurations = ['archives']
@@ -45,15 +45,15 @@ bintray {
         version {
             name = relVersion
             released = new Date()
-            mavenCentralSync {
-                sync = true
-                user = System.getenv('SONATYPE_USERNAME')
-                password = System.getenv('SONATYPE_PASSWORD')
-            }
-            gpg {
-                sign = true
-                passphrase = System.getenv('BINTRAY_GPG_KEY')
-            }
+//            mavenCentralSync {
+//                sync = true
+//                user = System.getenv('SONATYPE_USERNAME')
+//                password = System.getenv('SONATYPE_PASSWORD')
+//            }
+//            gpg {
+//                sign = true
+//                passphrase = System.getenv('BINTRAY_GPG_KEY')
+//            }
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -18,12 +18,12 @@ buildscript {
     }
     dependencies {
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:2.0'
     }
-    // Netty build does not need android dependencies.
+    // Android specific dependencies.
     if (project.properties.get('buildPlatform', 'android') == 'android') {
         dependencies {
             classpath 'com.android.tools.build:gradle:3.0.0-beta6'
+            classpath 'com.github.dcendents:android-maven-gradle-plugin:2.0'
         }
     }
 }


### PR DESCRIPTION
This one is interesting.

To do a release run:
```
BINTRAY_USER=bintray_username BINTRAY_KEY=bintray_token AUTOBAHN_BUILD_VERSION=version_to_release gradle bintrayUpload -PbuildPlatform=android
```
For Netty release just replace 'android' with 'netty'. For Android the package will be name autobahn-android, for Netty, it will be called autobahn-java.

(Obviously this depends on our account of Bintray)
