### PR TITLE
Show version badge for docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Client library providing [WAMP](http://wamp-proto.org/) on Java 8 ([Netty](https
 
 [![Docker Hub](https://img.shields.io/badge/docker-ready-blue.svg)](https://hub.docker.com/r/crossbario/autobahn-java/) |
 [![Travis](https://travis-ci.org/crossbario/autobahn-java.svg?branch=master)](https://travis-ci.org/crossbario/autobahn-java)
-[![Docs](https://javadoc.io/badge/io.crossbar.autobahn/autobahn-android.svg)](https://javadoc.io/doc/io.crossbar.autobahn/autobahn-android)
+[![Docs](https://javadoc.io/badge/io.crossbar.autobahn/autobahn-android.svg?label=docs)](https://javadoc.io/doc/io.crossbar.autobahn/autobahn-android)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Client library providing [WAMP](http://wamp-proto.org/) on Java 8 ([Netty](https
 
 [![Docker Hub](https://img.shields.io/badge/docker-ready-blue.svg)](https://hub.docker.com/r/crossbario/autobahn-java/) |
 [![Travis](https://travis-ci.org/crossbario/autobahn-java.svg?branch=master)](https://travis-ci.org/crossbario/autobahn-java)
-[![Docs](https://img.shields.io/badge/Docs-latest-ff69b4.svg)](https://crossbario.github.io/autobahn-java-docs/)
+[![Docs](https://javadoc.io/badge/io.crossbar.autobahn/autobahn-android.svg)](https://javadoc.io/doc/io.crossbar.autobahn/autobahn-android)
 
 ---
 


### PR DESCRIPTION
Docs are now hosted at https://javadoc.io/doc/io.crossbar.autobahn/autobahn-android/17.10.2 -- This makes our life easier as they are always upto date whenever we do a new release. Also javadoc.io has an easy way to get documentation for older releases.