### PR TITLE
Simplify the Client API

### DIFF
--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/Client.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/Client.java
@@ -22,6 +22,7 @@ import java.util.logging.Logger;
 import io.crossbar.autobahn.wamp.interfaces.ITransport;
 import io.crossbar.autobahn.wamp.interfaces.IAuthenticator;
 import io.crossbar.autobahn.wamp.types.ExitInfo;
+import io.crossbar.autobahn.wamp.utils.Platform;
 
 public class Client {
 
@@ -36,11 +37,7 @@ public class Client {
 
     public Client(String webSocketURL) {
         mTransports = new ArrayList<>();
-        try {
-            mTransports.add(selectTransport(webSocketURL));
-        } catch (Exception e) {
-            throw new RuntimeException(e.getMessage());
-        }
+        mTransports.add(Platform.autoSelectTransport(webSocketURL));
     }
 
     public Client(ITransport transport) {
@@ -78,16 +75,6 @@ public class Client {
     public Client(List<ITransport> transports, ExecutorService executor) {
         this(transports);
         mExecutor = executor;
-    }
-
-    private ITransport selectTransport(String webSocketURL) throws Exception {
-        Class<?> transportClass;
-        if (System.getProperty("java.vendor").equals("The Android Project")) {
-            transportClass = Class.forName("io.crossbar.autobahn.wamp.transports.AndroidWebSocket");
-        } else {
-            transportClass = Class.forName("io.crossbar.autobahn.wamp.transports.NettyTransport");
-        }
-        return (ITransport) transportClass.getConstructor(String.class).newInstance(webSocketURL);
     }
 
     private ExecutorService getExecutor() {

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/Client.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/Client.java
@@ -39,11 +39,7 @@ public class Client {
         try {
             mTransports.add(selectTransport(webSocketURL));
         } catch (Exception e) {
-            // We don't really expect to be here. Its most likely
-            // that we changed our WAMP transports names.
-            // The other reason could be the change of our transport'
-            // constructor.
-            e.printStackTrace();
+            throw new RuntimeException(e.getMessage());
         }
     }
 

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/Client.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/Client.java
@@ -62,6 +62,19 @@ public class Client {
         mExecutor = executor;
     }
 
+    public Client(Session session, String webSocketURL, String realm) {
+        this(webSocketURL);
+        mSession = session;
+        mRealm = realm;
+    }
+
+    public Client(Session session, String webSocketURL, String realm, ExecutorService executor) {
+        this(webSocketURL);
+        mSession = session;
+        mRealm = realm;
+        mExecutor = executor;
+    }
+
     public Client(List<ITransport> transports) {
         mTransports = transports;
     }

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/Client.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/Client.java
@@ -47,6 +47,16 @@ public class Client {
         }
     }
 
+    public Client(ITransport transport) {
+        mTransports = new ArrayList<>();
+        mTransports.add(transport);
+    }
+
+    public Client(ITransport transport, ExecutorService executor) {
+        this(transport);
+        mExecutor = executor;
+    }
+
     public Client(String webSocketURL, ExecutorService executor) {
         this(webSocketURL);
         mExecutor = executor;

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/utils/Platform.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/utils/Platform.java
@@ -1,3 +1,14 @@
+///////////////////////////////////////////////////////////////////////////////
+//
+//   AutobahnJava - http://crossbar.io/autobahn
+//
+//   Copyright (c) Crossbar.io Technologies GmbH and contributors
+//
+//   Licensed under the MIT License.
+//   http://www.opensource.org/licenses/mit-license.php
+//
+///////////////////////////////////////////////////////////////////////////////
+
 package io.crossbar.autobahn.wamp.utils;
 
 import io.crossbar.autobahn.wamp.interfaces.ITransport;

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/utils/Platform.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/utils/Platform.java
@@ -1,0 +1,41 @@
+package io.crossbar.autobahn.wamp.utils;
+
+import io.crossbar.autobahn.wamp.interfaces.ITransport;
+
+public class Platform {
+
+    /**
+     * Checks if code is running on Android.
+     *
+     * @return boolean representing whether the underlying platform
+     *     is Android based
+     */
+    public static boolean isAndroid() {
+        return System.getProperty("java.vendor").equals("The Android Project");
+    }
+
+    /**
+     * Automatically returns a WebSocket based transport for WAMP based on the
+     * underlying platform.
+     *
+     * @param webSocketURL websocket url to use for initializing of the transport
+     * @return an instance of ITransport suitable for the underlying platform.
+     * @throws RuntimeException most probably if the path of transport we are trying
+     *     to initialize changed OR its constructor changed.
+     */
+    public static ITransport autoSelectTransport(String webSocketURL) throws RuntimeException {
+        Class<?> transportClass;
+
+        try {
+            if (isAndroid()) {
+                transportClass = Class.forName("io.crossbar.autobahn.wamp.transports.AndroidWebSocket");
+            } else {
+                transportClass = Class.forName("io.crossbar.autobahn.wamp.transports.NettyTransport");
+            }
+
+            return (ITransport) transportClass.getConstructor(String.class).newInstance(webSocketURL);
+        } catch (Exception e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
+}

--- a/demo-gallery/src/main/java/io/crossbar/autobahn/demogallery/ExampleClient.java
+++ b/demo-gallery/src/main/java/io/crossbar/autobahn/demogallery/ExampleClient.java
@@ -23,6 +23,7 @@ import io.crossbar.autobahn.wamp.types.Publication;
 import io.crossbar.autobahn.wamp.types.Registration;
 import io.crossbar.autobahn.wamp.types.SessionDetails;
 import io.crossbar.autobahn.wamp.types.Subscription;
+import io.crossbar.autobahn.wamp.utils.Platform;
 
 public class ExampleClient {
 
@@ -39,11 +40,7 @@ public class ExampleClient {
         // Now create a transport list to try and add transports to it.
         // In our case, we currently only have Netty based WAMP-over-WebSocket.
         List<ITransport> transports = new ArrayList<>();
-        try {
-            transports.add(selectTransport(websocketURL));
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
+        transports.add(Platform.autoSelectTransport(websocketURL));
 
         // Now provide a list of authentication methods.
         // We only support anonymous auth currently.
@@ -54,21 +51,6 @@ public class ExampleClient {
         Client client = new Client(transports, executor);
         client.add(session, realm, authenticators);
         return client.connect();
-    }
-
-    // Convenience method to dynamically return a transport based on the underlying platform.
-    // No rocket science here.
-    // Could easily replace all the underlying code with just
-    // return new AndroidWebSocket(webSocketURL);
-    // If the underlying platform is known upfront.
-    private ITransport selectTransport(String webSocketURL) throws Exception {
-        Class<?> transportClass;
-        if (System.getProperty("java.vendor").equals("The Android Project")) {
-            transportClass = Class.forName("io.crossbar.autobahn.wamp.transports.AndroidWebSocket");
-        } else {
-            transportClass = Class.forName("io.crossbar.autobahn.wamp.transports.NettyTransport");
-        }
-        return (ITransport) transportClass.getConstructor(String.class).newInstance(webSocketURL);
     }
 
     private void onConnectCallback(Session session) {

--- a/demo-gallery/src/main/java/io/crossbar/autobahn/demogallery/ExampleClient.java
+++ b/demo-gallery/src/main/java/io/crossbar/autobahn/demogallery/ExampleClient.java
@@ -1,3 +1,14 @@
+///////////////////////////////////////////////////////////////////////////////
+//
+//   AutobahnJava - http://crossbar.io/autobahn
+//
+//   Copyright (c) Crossbar.io Technologies GmbH and contributors
+//
+//   Licensed under the MIT License.
+//   http://www.opensource.org/licenses/mit-license.php
+//
+///////////////////////////////////////////////////////////////////////////////
+
 package io.crossbar.autobahn.demogallery;
 
 import java.util.ArrayList;


### PR DESCRIPTION
- Overloads the Client class constructor for convenience.
- Overloads Client.add() for convenience.

Reasons for the change are here https://github.com/crossbario/autobahn-java/issues/302