### PR TITLE
WAMP: Session.subscribe POJOs support

### DIFF
--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/interfaces/ISession.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/interfaces/ISession.java
@@ -41,63 +41,102 @@ import io.crossbar.autobahn.wamp.types.Subscription;
 
 public interface ISession {
 
-//    CompletableFuture<Subscription> subscribe(
-//            String topic,
-//            IEventHandler handler,
-//            SubscribeOptions options);
-
-    <T> CompletableFuture<Subscription> subscribe(
+    CompletableFuture<Subscription> subscribe(
             String topic,
-            Consumer<T> handler);
+            Consumer<List<Object>> handler);
+
+    CompletableFuture<Subscription> subscribe(
+            String topic,
+            Consumer<List<Object>> handler,
+            SubscribeOptions options);
 
     <T> CompletableFuture<Subscription> subscribe(
             String topic,
             Consumer<T> handler,
-            SubscribeOptions options);
+            TypeReference<T> resultType);
 
     <T> CompletableFuture<Subscription> subscribe(
             String topic,
-            Function<T, CompletableFuture<ReceptionResult>> handler);
+            Consumer<T> handler,
+            TypeReference<T> resultType,
+            SubscribeOptions options);
+
+    CompletableFuture<Subscription> subscribe(
+            String topic,
+            Function<List<Object>, CompletableFuture<ReceptionResult>> handler);
+
+    CompletableFuture<Subscription> subscribe(
+            String topic,
+            Function<List<Object>, CompletableFuture<ReceptionResult>> handler,
+            SubscribeOptions options);
 
     <T> CompletableFuture<Subscription> subscribe(
             String topic,
             Function<T, CompletableFuture<ReceptionResult>> handler,
-            SubscribeOptions options);
+            TypeReference<T> resultType);
 
     <T> CompletableFuture<Subscription> subscribe(
             String topic,
-            BiConsumer<T, EventDetails> handler);
+            Function<T, CompletableFuture<ReceptionResult>> handler,
+            TypeReference<T> resultType,
+            SubscribeOptions options);
+
+    CompletableFuture<Subscription> subscribe(
+            String topic,
+            BiConsumer<List<Object>, EventDetails> handler);
+
+    CompletableFuture<Subscription> subscribe(
+            String topic,
+            BiConsumer<List<Object>, EventDetails> handler,
+            SubscribeOptions options);
 
     <T> CompletableFuture<Subscription> subscribe(
             String topic,
             BiConsumer<T, EventDetails> handler,
-            SubscribeOptions options);
+            TypeReference<T> resultType);
 
     <T> CompletableFuture<Subscription> subscribe(
             String topic,
-            BiFunction<T, EventDetails, CompletableFuture<ReceptionResult>> handler);
+            BiConsumer<T, EventDetails> handler,
+            TypeReference<T> resultType,
+            SubscribeOptions options);
+
+    CompletableFuture<Subscription> subscribe(
+            String topic,
+            BiFunction<List<Object>, EventDetails, CompletableFuture<ReceptionResult>> handler);
+
+    CompletableFuture<Subscription> subscribe(
+            String topic,
+            BiFunction<List<Object>, EventDetails, CompletableFuture<ReceptionResult>> handler,
+            SubscribeOptions options);
 
     <T> CompletableFuture<Subscription> subscribe(
             String topic,
             BiFunction<T, EventDetails, CompletableFuture<ReceptionResult>> handler,
+            TypeReference<T> resultType);
+
+    <T> CompletableFuture<Subscription> subscribe(
+            String topic,
+            BiFunction<T, EventDetails, CompletableFuture<ReceptionResult>> handler,
+            TypeReference<T> resultType,
             SubscribeOptions options);
 
-    <T, U> CompletableFuture<Subscription> subscribe(
+    CompletableFuture<Subscription> subscribe(
             String topic,
-            TriConsumer<T, U, EventDetails> handler);
+            TriConsumer<List<Object>, Map<String, Object>, EventDetails> handler);
 
-    <T, U> CompletableFuture<Subscription> subscribe(
+    CompletableFuture<Subscription> subscribe(
             String topic,
-            TriConsumer<T, U, EventDetails> handler,
+            TriConsumer<List<Object>, Map<String, Object>, EventDetails> handler,
             SubscribeOptions options);
 
-    <T, U> CompletableFuture<Subscription> subscribe(
+    CompletableFuture<Subscription> subscribe(
             String topic,
-            TriFunction<T, U, EventDetails, CompletableFuture<ReceptionResult>> handler);
+            TriFunction<List<Object>, Map<String, Object>, EventDetails, CompletableFuture<ReceptionResult>> handler);
 
-    <T, U> CompletableFuture<Subscription> subscribe(
+    CompletableFuture<Subscription> subscribe(
             String topic,
-            TriFunction<T, U, EventDetails, CompletableFuture<ReceptionResult>> handler,
+            TriFunction<List<Object>, Map<String, Object>, EventDetails, CompletableFuture<ReceptionResult>> handler,
             SubscribeOptions options);
 
     CompletableFuture<Publication> publish(

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/requests/SubscribeRequest.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/requests/SubscribeRequest.java
@@ -11,6 +11,8 @@
 
 package io.crossbar.autobahn.wamp.requests;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+
 import java.util.concurrent.CompletableFuture;
 
 import io.crossbar.autobahn.wamp.types.Subscription;
@@ -19,13 +21,15 @@ import io.crossbar.autobahn.wamp.types.Subscription;
 public class SubscribeRequest extends Request {
     public final String topic;
     public final CompletableFuture<Subscription> onReply;
+    public final TypeReference resultType;
     public final Object handler;
 
     public SubscribeRequest(long request, String topic, CompletableFuture<Subscription> onReply,
-                            Object handler) {
+                            TypeReference resultType, Object handler) {
         super(request);
         this.topic = topic;
         this.onReply = onReply;
+        this.resultType = resultType;
         this.handler = handler;
     }
 }

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/types/Subscription.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/types/Subscription.java
@@ -11,14 +11,18 @@
 
 package io.crossbar.autobahn.wamp.types;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+
 public class Subscription {
     public final long subscription;
     public final String topic;
+    public final TypeReference resultType;
     public final Object handler;
 
-    public Subscription(long subscription, String topic, Object handler) {
+    public Subscription(long subscription, String topic, TypeReference resultType, Object handler) {
         this.subscription = subscription;
         this.topic = topic;
+        this.resultType = resultType;
         this.handler = handler;
     }
 }

--- a/demo-gallery/src/main/java/io/crossbar/autobahn/demogallery/ExampleClient.java
+++ b/demo-gallery/src/main/java/io/crossbar/autobahn/demogallery/ExampleClient.java
@@ -53,12 +53,12 @@ public class ExampleClient {
 
     private void onJoinCallback(Session session, SessionDetails details) {
         CompletableFuture<Registration> regFuture = session.register(
-                "com.example.add2", this::add2, null);
+                "com.example.add2", this::add2);
         regFuture.thenAccept(
                 registration -> LOGGER.info("Registered procedure: com.example.add2"));
 
         CompletableFuture<Subscription> subFuture = session.subscribe(
-                "com.example.oncounter", this::onCounter, null);
+                "com.example.oncounter", this::onCounter);
         subFuture.thenAccept(subscription ->
                 LOGGER.info(String.format("Subscribed to topic: %s", subscription.topic)));
 


### PR DESCRIPTION
This also fixes a very important bug:
On current master we don't support POJOs for Subscribe but our code allows us to write callbacks that make use of POJOs which results in the callback never executing.