### PR TITLE
Extend POJO APIs for call/subscribe to accept class references

### DIFF
--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/Session.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/Session.java
@@ -258,11 +258,11 @@ public class Session implements ISession, ITransportHandler {
             }
 
             mCallRequests.remove(msg.request);
-            if (request.resultType != null) {
+            if (request.resultTypeRef != null) {
                 // FIXME: check args length > 1 and == 0, and kwargs != null
                 // we cannot currently POJO automap these cases!
                 request.onReply.complete(mSerializer.convertValue(
-                        msg.args.get(0), request.resultType));
+                        msg.args.get(0), request.resultTypeRef));
             } else {
                 request.onReply.complete(new CallResult(msg.args, msg.kwargs));
             }
@@ -279,8 +279,8 @@ public class Session implements ISession, ITransportHandler {
             if (!mSubscriptions.containsKey(msg.subscription)) {
                 mSubscriptions.put(msg.subscription, new ArrayList<>());
             }
-            Subscription subscription = new Subscription(
-                    msg.subscription, request.topic, request.resultType, request.handler);
+            Subscription subscription = new Subscription(msg.subscription, request.topic,
+                    request.resultTypeRef, request.resultTypeClass, request.handler);
             mSubscriptions.get(msg.subscription).add(subscription);
             request.onReply.complete(subscription);
         } else if (message instanceof Event) {
@@ -304,8 +304,14 @@ public class Session implements ISession, ITransportHandler {
 
                 CompletableFuture future = null;
                 // Check if we expect a POJO.
-                Object arg = subscription.resultType == null ? msg.args:
-                        mSerializer.convertValue(msg.args.get(0), subscription.resultType);
+                Object arg;
+                if (subscription.resultTypeRef != null) {
+                    arg = mSerializer.convertValue(msg.args.get(0), subscription.resultTypeRef);
+                } else if (subscription.resultTypeClass != null) {
+                    arg = mSerializer.convertValue(msg.args.get(0), subscription.resultTypeClass);
+                } else {
+                    arg = msg.args;
+                }
 
                 if (subscription.handler instanceof Consumer) {
                     Consumer handler = (Consumer) subscription.handler;
@@ -495,20 +501,21 @@ public class Session implements ISession, ITransportHandler {
     private <T> CompletableFuture<Subscription> reallySubscribe(
             String topic,
             Object handler,
-            TypeReference<T> resultType,
-            SubscribeOptions options) {
+            SubscribeOptions options,
+            TypeReference<T> resultTypeRef,
+            Class<T> resultTypeClass) {
         throwIfNotConnected();
         CompletableFuture<Subscription> future = new CompletableFuture<>();
         long requestID = mIDGenerator.next();
-        mSubscribeRequests.put(requestID,
-                new SubscribeRequest(requestID, topic, future, resultType, handler));
+        mSubscribeRequests.put(requestID, new SubscribeRequest(requestID, topic, future,
+                resultTypeRef, resultTypeClass, handler));
         send(new Subscribe(requestID, options, topic));
         return future;
     }
 
     @Override
     public CompletableFuture<Subscription> subscribe(String topic, Consumer<List<Object>> handler) {
-        return reallySubscribe(topic, handler, null, null);
+        return reallySubscribe(topic, handler, null, null, null);
     }
 
     @Override
@@ -516,7 +523,7 @@ public class Session implements ISession, ITransportHandler {
             String topic,
             Consumer<List<Object>> handler,
             SubscribeOptions options) {
-        return reallySubscribe(topic, handler, null, options);
+        return reallySubscribe(topic, handler, options, null, null);
     }
 
     @Override
@@ -524,22 +531,40 @@ public class Session implements ISession, ITransportHandler {
             String topic,
             Consumer<T> handler,
             TypeReference<T> resultType) {
-        return reallySubscribe(topic, handler, resultType, null);
+        return reallySubscribe(topic, handler, null, resultType, null);
     }
 
     @Override
-    public <T> CompletableFuture<Subscription> subscribe(String topic,
-                                                         Consumer<T> handler,
-                                                         TypeReference<T> resultType,
-                                                         SubscribeOptions options) {
-        return reallySubscribe(topic, handler, resultType, options);
+    public <T> CompletableFuture<Subscription> subscribe(
+            String topic,
+            Consumer<T> handler,
+            Class<T> resultType) {
+        return reallySubscribe(topic, handler, null, null, resultType);
+    }
+
+    @Override
+    public <T> CompletableFuture<Subscription> subscribe(
+            String topic,
+            Consumer<T> handler,
+            TypeReference<T> resultType,
+            SubscribeOptions options) {
+        return reallySubscribe(topic, handler, options, resultType, null);
+    }
+
+    @Override
+    public <T> CompletableFuture<Subscription> subscribe(
+            String topic,
+            Consumer<T> handler,
+            Class<T> resultType,
+            SubscribeOptions options) {
+        return reallySubscribe(topic, handler, options, null, resultType);
     }
 
     @Override
     public CompletableFuture<Subscription> subscribe(
             String topic,
             Function<List<Object>, CompletableFuture<ReceptionResult>> handler) {
-        return reallySubscribe(topic, handler, null, null);
+        return reallySubscribe(topic, handler, null, null, null);
     }
 
     @Override
@@ -547,7 +572,7 @@ public class Session implements ISession, ITransportHandler {
             String topic,
             Function<List<Object>, CompletableFuture<ReceptionResult>> handler,
             SubscribeOptions options) {
-        return reallySubscribe(topic, handler, null, options);
+        return reallySubscribe(topic, handler, options, null, null);
     }
 
     @Override
@@ -555,7 +580,15 @@ public class Session implements ISession, ITransportHandler {
             String topic,
             Function<T,CompletableFuture<ReceptionResult>> handler,
             TypeReference<T> resultType) {
-        return reallySubscribe(topic, handler, resultType, null);
+        return reallySubscribe(topic, handler, null, resultType, null);
+    }
+
+    @Override
+    public <T> CompletableFuture<Subscription> subscribe(
+            String topic,
+            Function<T, CompletableFuture<ReceptionResult>> handler,
+            Class<T> resultType) {
+        return reallySubscribe(topic, handler, null, null, resultType);
     }
 
     @Override
@@ -564,21 +597,30 @@ public class Session implements ISession, ITransportHandler {
             Function<T, CompletableFuture<ReceptionResult>> handler,
             TypeReference<T> resultType,
             SubscribeOptions options) {
-        return reallySubscribe(topic, handler, resultType, options);
+        return reallySubscribe(topic, handler, options, resultType, null);
+    }
+
+    @Override
+    public <T> CompletableFuture<Subscription> subscribe(
+            String topic,
+            Function<T, CompletableFuture<ReceptionResult>> handler,
+            Class<T> resultType,
+            SubscribeOptions options) {
+        return reallySubscribe(topic, handler, options, null, resultType);
     }
 
     @Override
     public CompletableFuture<Subscription> subscribe(
             String topic,
             BiConsumer<List<Object>, EventDetails> handler) {
-        return reallySubscribe(topic, handler, null, null);
+        return reallySubscribe(topic, handler, null, null, null);
     }
 
     @Override
     public CompletableFuture<Subscription> subscribe(
             String topic,
             BiConsumer<List<Object>, EventDetails> handler, SubscribeOptions options) {
-        return reallySubscribe(topic, handler, null, options);
+        return reallySubscribe(topic, handler, options, null, null);
     }
 
     @Override
@@ -586,7 +628,15 @@ public class Session implements ISession, ITransportHandler {
             String topic,
             BiConsumer<T, EventDetails> handler,
             TypeReference<T> resultType) {
-        return reallySubscribe(topic, handler, resultType, null);
+        return reallySubscribe(topic, handler, null, resultType, null);
+    }
+
+    @Override
+    public <T> CompletableFuture<Subscription> subscribe(
+            String topic,
+            BiConsumer<T, EventDetails> handler,
+            Class<T> resultType) {
+        return reallySubscribe(topic, handler, null, null, resultType);
     }
 
     @Override
@@ -595,14 +645,23 @@ public class Session implements ISession, ITransportHandler {
             BiConsumer<T, EventDetails> handler,
             TypeReference<T> resultType,
             SubscribeOptions options) {
-        return reallySubscribe(topic, handler, resultType, options);
+        return reallySubscribe(topic, handler, options, resultType, null);
+    }
+
+    @Override
+    public <T> CompletableFuture<Subscription> subscribe(
+            String topic,
+            BiConsumer<T, EventDetails> handler,
+            Class<T> resultType,
+            SubscribeOptions options) {
+        return reallySubscribe(topic, handler, options, null, resultType);
     }
 
     @Override
     public CompletableFuture<Subscription> subscribe(
             String topic,
             BiFunction<List<Object>, EventDetails, CompletableFuture<ReceptionResult>> handler) {
-        return reallySubscribe(topic, handler, null, null);
+        return reallySubscribe(topic, handler, null, null, null);
     }
 
     @Override
@@ -610,7 +669,7 @@ public class Session implements ISession, ITransportHandler {
             String topic,
             BiFunction<List<Object>, EventDetails, CompletableFuture<ReceptionResult>> handler,
             SubscribeOptions options) {
-        return reallySubscribe(topic, handler, null, options);
+        return reallySubscribe(topic, handler, options, null, null);
     }
 
     @Override
@@ -618,7 +677,15 @@ public class Session implements ISession, ITransportHandler {
             String topic,
             BiFunction<T, EventDetails, CompletableFuture<ReceptionResult>> handler,
             TypeReference<T> resultType) {
-        return reallySubscribe(topic, handler, resultType, null);
+        return reallySubscribe(topic, handler, null, resultType, null);
+    }
+
+    @Override
+    public <T> CompletableFuture<Subscription> subscribe(
+            String topic,
+            BiFunction<T, EventDetails, CompletableFuture<ReceptionResult>> handler,
+            Class<T> resultType) {
+        return reallySubscribe(topic, handler, null, null, resultType);
     }
 
     @Override
@@ -627,14 +694,23 @@ public class Session implements ISession, ITransportHandler {
             BiFunction<T, EventDetails, CompletableFuture<ReceptionResult>> handler,
             TypeReference<T> resultType,
             SubscribeOptions options) {
-        return reallySubscribe(topic, handler, resultType, options);
+        return reallySubscribe(topic, handler, options, resultType, null);
+    }
+
+    @Override
+    public <T> CompletableFuture<Subscription> subscribe(
+            String topic,
+            BiFunction<T, EventDetails, CompletableFuture<ReceptionResult>> handler,
+            Class<T> resultType,
+            SubscribeOptions options) {
+        return reallySubscribe(topic, handler, options, null, resultType);
     }
 
     @Override
     public CompletableFuture<Subscription> subscribe(
             String topic,
             TriConsumer<List<Object>, Map<String, Object>, EventDetails> handler) {
-        return reallySubscribe(topic, handler, null, null);
+        return reallySubscribe(topic, handler, null, null, null);
     }
 
     @Override
@@ -642,7 +718,7 @@ public class Session implements ISession, ITransportHandler {
             String topic,
             TriConsumer<List<Object>, Map<String, Object>, EventDetails> handler,
             SubscribeOptions options) {
-        return reallySubscribe(topic, handler, null, options);
+        return reallySubscribe(topic, handler, options, null, null);
     }
 
     @Override
@@ -650,7 +726,7 @@ public class Session implements ISession, ITransportHandler {
             String topic,
             TriFunction<List<Object>, Map<String, Object>, EventDetails,
                     CompletableFuture<ReceptionResult>> handler) {
-        return reallySubscribe(topic, handler, null, null);
+        return reallySubscribe(topic, handler, null, null, null);
     }
 
     @Override
@@ -659,7 +735,7 @@ public class Session implements ISession, ITransportHandler {
             TriFunction<List<Object>, Map<String, Object>, EventDetails,
                     CompletableFuture<ReceptionResult>> handler,
             SubscribeOptions options) {
-        return reallySubscribe(topic, handler, null, options);
+        return reallySubscribe(topic, handler, options, null, null);
     }
 
     private CompletableFuture<Publication> reallyPublish(String topic, List<Object> args,
@@ -816,15 +892,17 @@ public class Session implements ISession, ITransportHandler {
     private <T> CompletableFuture<T> reallyCall(
             String procedure,
             List<Object> args, Map<String, Object> kwargs,
-            TypeReference<T> resultType, CallOptions options) {
+            CallOptions options,
+            TypeReference<T> resultTypeReference,
+            Class<T> resultTypeClass) {
         throwIfNotConnected();
 
         CompletableFuture<T> future = new CompletableFuture<>();
 
         long requestID = mIDGenerator.next();
 
-        mCallRequests.put(requestID,
-                new CallRequest(requestID, procedure, future, options, resultType));
+        mCallRequests.put(requestID, new CallRequest(requestID, procedure, future, options,
+                resultTypeReference, resultTypeClass));
 
         if (options == null) {
             send(new Call(requestID, procedure, args, kwargs, 0));
@@ -836,13 +914,26 @@ public class Session implements ISession, ITransportHandler {
 
     @Override
     public CompletableFuture<CallResult> call(String procedure) {
-        return reallyCall(procedure, null, null, null, null);
+        return reallyCall(procedure, null, null, null,
+                null, null);
     }
 
     @Override
     public CompletableFuture<CallResult> call(String procedure, Object... args) {
         return reallyCall(procedure, Arrays.asList(args), null,
-                null, null);
+                null, null, null);
+    }
+
+    @Override
+    public <T> CompletableFuture<T> call(String procedure, TypeReference<T> resultType) {
+        return reallyCall(procedure, null, null, null, resultType,
+                null);
+    }
+
+    @Override
+    public <T> CompletableFuture<T> call(String procedure, Class<T> resultType) {
+        return reallyCall(procedure, null, null, null, null,
+                resultType);
     }
 
     @Override
@@ -850,12 +941,104 @@ public class Session implements ISession, ITransportHandler {
             String procedure,
             CallOptions options,
             Object... args) {
-        return reallyCall(procedure, Arrays.asList(args), null, null, options);
+        return reallyCall(procedure, Arrays.asList(args), null, options,
+                null, null);
+    }
+
+    @Override
+    public <T> CompletableFuture<T> call(
+            String procedure,
+            TypeReference<T> resultType,
+            CallOptions options) {
+        return reallyCall(procedure, null, null, options, resultType,
+                null);
+    }
+
+    @Override
+    public <T> CompletableFuture<T> call(
+            String procedure,
+            Class<T> resultType,
+            CallOptions options) {
+        return reallyCall(procedure, null, null, options, null,
+                resultType);
+    }
+
+    @Override
+    public <T> CompletableFuture<T> call(
+            String procedure,
+            List<Object> args,
+            TypeReference<T> resultType) {
+        return reallyCall(procedure, args, null, null, resultType,
+                null);
+    }
+
+    @Override
+    public <T> CompletableFuture<T> call(String procedure, List<Object> args, Class<T> resultType) {
+        return reallyCall(procedure, args, null, null, null,
+                resultType);
+    }
+
+    @Override
+    public <T> CompletableFuture<T> call(
+            String procedure,
+            List<Object> args,
+            TypeReference<T> resultType,
+            CallOptions options) {
+        return reallyCall(procedure, args, null, options, resultType, null);
+    }
+
+    @Override
+    public <T> CompletableFuture<T> call(
+            String procedure,
+            List<Object> args,
+            Class<T> resultType,
+            CallOptions options) {
+        return reallyCall(procedure, args, null, options, null,
+                resultType);
     }
 
     @Override
     public CompletableFuture<CallResult> call(String procedure, Map<String, Object> kwargs) {
-        return reallyCall(procedure, null, kwargs, null, null);
+        return reallyCall(procedure, null, kwargs, null, null,
+                null);
+    }
+
+    @Override
+    public <T> CompletableFuture<T> call(
+            String procedure,
+            Map<String, Object> kwargs,
+            TypeReference<T> resultType) {
+        return reallyCall(procedure, null, kwargs, null, resultType,
+                null);
+    }
+
+    @Override
+    public <T> CompletableFuture<T> call(
+            String procedure,
+            Map<String, Object> kwargs,
+            Class<T> resultType) {
+        return reallyCall(procedure, null, kwargs, null, null,
+                resultType);
+    }
+
+    @Override
+    public <T> CompletableFuture<T> call(
+            String procedure,
+            Map<String, Object> kwargs,
+            TypeReference<T> resultType,
+            CallOptions options) {
+        return reallyCall(procedure, null, kwargs, options, resultType,
+                null);
+    }
+
+    @Override
+    public <T> CompletableFuture<T> call(
+            String procedure,
+            Map<String, Object> kwargs,
+            Class<T> resultType,
+            CallOptions options) {
+        return reallyCall(procedure, null, kwargs, options, null,
+                resultType);
     }
 
     @Override
@@ -863,31 +1046,67 @@ public class Session implements ISession, ITransportHandler {
             String procedure,
             Map<String, Object> kwargs,
             CallOptions options) {
-        return reallyCall(procedure, null, kwargs, null, options);
+        return reallyCall(procedure, null, kwargs, options, null,
+                null);
     }
 
     @Override
     public CompletableFuture<CallResult> call(
             String procedure,
-            List<Object> args, Map<String, Object> kwargs,
+            List<Object> args,
+            Map<String, Object> kwargs,
             CallOptions options) {
-        return reallyCall(procedure, args, kwargs, null, options);
+        return reallyCall(procedure, args, kwargs, options, null,
+                null);
     }
 
     @Override
     public <T> CompletableFuture<T> call(
             String procedure,
-            List<Object> args, Map<String, Object> kwargs,
-            TypeReference<T> resultType, CallOptions options) {
-        return reallyCall(procedure, args, kwargs, resultType, options);
+            List<Object> args,
+            Map<String, Object> kwargs,
+            TypeReference<T> resultType) {
+        return reallyCall(procedure, args, kwargs, null, resultType, null);
     }
 
     @Override
     public <T> CompletableFuture<T> call(
             String procedure,
-            TypeReference<T> resultType, CallOptions options,
+            List<Object> args,
+            Map<String, Object> kwargs,
+            Class<T> resultType) {
+        return reallyCall(procedure, args, kwargs, null, null,
+                resultType);
+    }
+
+    @Override
+    public <T> CompletableFuture<T> call(
+            String procedure,
+            List<Object> args,
+            Map<String, Object> kwargs,
+            TypeReference<T> resultType,
+            CallOptions options) {
+        return reallyCall(procedure, args, kwargs, options, resultType, null);
+    }
+
+    @Override
+    public <T> CompletableFuture<T> call(
+            String procedure,
+            List<Object> args,
+            Map<String, Object> kwargs,
+            Class<T> resultType,
+            CallOptions options) {
+        return reallyCall(procedure, args, kwargs, options, null, resultType);
+    }
+
+    @Override
+    public <T> CompletableFuture<T> call(
+            String procedure,
+            TypeReference<T> resultType,
+            CallOptions options,
             Object... args) {
-        return reallyCall(procedure, Arrays.asList(args), null, resultType, options);
+        return reallyCall(procedure, Arrays.asList(args), null, options, resultType,
+                null);
     }
 
     @Override

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/Session.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/Session.java
@@ -263,6 +263,9 @@ public class Session implements ISession, ITransportHandler {
                 // we cannot currently POJO automap these cases!
                 request.onReply.complete(mSerializer.convertValue(
                         msg.args.get(0), request.resultTypeRef));
+            } else if (request.resultTypeClass != null) {
+                request.onReply.complete(mSerializer.convertValue(
+                        msg.args.get(0), request.resultTypeClass));
             } else {
                 request.onReply.complete(new CallResult(msg.args, msg.kwargs));
             }

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/interfaces/ISerializer.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/interfaces/ISerializer.java
@@ -52,6 +52,12 @@ public abstract class ISerializer {
         return mapper.convertValue(fromValue, toValueTypeRef);
     }
 
+    public <T> T convertValue(Object fromValue, Class<T> toValueTypeClass) {
+        // https://github.com/FasterXML/jackson-databind#tutorial-fancier-stuff-conversions
+        // ResultType result = mapper.convertValue(sourceObject, ResultType.class);
+        return mapper.convertValue(fromValue, toValueTypeClass);
+    }
+
     public boolean isBinary() {
         return true;
     }

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/interfaces/ISession.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/interfaces/ISession.java
@@ -77,6 +77,11 @@ public interface ISession {
             Consumer<T> handler,
             TypeReference<T> resultType);
 
+    <T> CompletableFuture<Subscription> subscribe(
+            String topic,
+            Consumer<T> handler,
+            Class<T> resultType);
+
     /**
      * Subscribes to a WAMP topic.
      * @param topic URI of the topic to subscribe
@@ -91,6 +96,12 @@ public interface ISession {
             String topic,
             Consumer<T> handler,
             TypeReference<T> resultType,
+            SubscribeOptions options);
+
+    <T> CompletableFuture<Subscription> subscribe(
+            String topic,
+            Consumer<T> handler,
+            Class<T> resultType,
             SubscribeOptions options);
 
     /**
@@ -131,6 +142,11 @@ public interface ISession {
             Function<T, CompletableFuture<ReceptionResult>> handler,
             TypeReference<T> resultType);
 
+    <T> CompletableFuture<Subscription> subscribe(
+            String topic,
+            Function<T, CompletableFuture<ReceptionResult>> handler,
+            Class<T> resultType);
+
     /**
      * Subscribes to a WAMP topic.
      * @param topic URI of the topic to subscribe
@@ -145,6 +161,12 @@ public interface ISession {
             String topic,
             Function<T, CompletableFuture<ReceptionResult>> handler,
             TypeReference<T> resultType,
+            SubscribeOptions options);
+
+    <T> CompletableFuture<Subscription> subscribe(
+            String topic,
+            Function<T, CompletableFuture<ReceptionResult>> handler,
+            Class<T> resultType,
             SubscribeOptions options);
 
     /**
@@ -185,6 +207,11 @@ public interface ISession {
             BiConsumer<T, EventDetails> handler,
             TypeReference<T> resultType);
 
+    <T> CompletableFuture<Subscription> subscribe(
+            String topic,
+            BiConsumer<T, EventDetails> handler,
+            Class<T> resultType);
+
     /**
      * Subscribes to a WAMP topic.
      * @param topic URI of the topic to subscribe
@@ -199,6 +226,12 @@ public interface ISession {
             String topic,
             BiConsumer<T, EventDetails> handler,
             TypeReference<T> resultType,
+            SubscribeOptions options);
+
+    <T> CompletableFuture<Subscription> subscribe(
+            String topic,
+            BiConsumer<T, EventDetails> handler,
+            Class<T> resultType,
             SubscribeOptions options);
 
     /**
@@ -239,6 +272,11 @@ public interface ISession {
             BiFunction<T, EventDetails, CompletableFuture<ReceptionResult>> handler,
             TypeReference<T> resultType);
 
+    <T> CompletableFuture<Subscription> subscribe(
+            String topic,
+            BiFunction<T, EventDetails, CompletableFuture<ReceptionResult>> handler,
+            Class<T> resultType);
+
     /**
      * Subscribes to a WAMP topic.
      * @param topic URI of the topic to subscribe
@@ -253,6 +291,12 @@ public interface ISession {
             String topic,
             BiFunction<T, EventDetails, CompletableFuture<ReceptionResult>> handler,
             TypeReference<T> resultType,
+            SubscribeOptions options);
+
+    <T> CompletableFuture<Subscription> subscribe(
+            String topic,
+            BiFunction<T, EventDetails, CompletableFuture<ReceptionResult>> handler,
+            Class<T> resultType,
             SubscribeOptions options);
 
     /**
@@ -506,6 +550,10 @@ public interface ISession {
      */
     CompletableFuture<CallResult> call(String procedure, Object... args);
 
+    <T> CompletableFuture<T> call(String procedure, TypeReference<T> resultType);
+
+    <T> CompletableFuture<T> call(String procedure, Class<T> resultType);
+
     /**
      * Calls a remote procedure.
      * @param procedure URI of the procedure to call
@@ -516,6 +564,32 @@ public interface ISession {
      */
     CompletableFuture<CallResult> call(String procedure, CallOptions options, Object... args);
 
+    <T> CompletableFuture<T> call(
+            String procedure,
+            TypeReference<T> resultType,
+            CallOptions options);
+
+    <T> CompletableFuture<T> call(String procedure, Class<T> resultType, CallOptions options);
+
+    <T> CompletableFuture<T> call(
+            String procedure,
+            List<Object> args,
+            TypeReference<T> resultType);
+
+    <T> CompletableFuture<T> call(String procedure, List<Object> args, Class<T> resultType);
+
+    <T> CompletableFuture<T> call(
+            String procedure,
+            List<Object> args,
+            TypeReference<T> resultType,
+            CallOptions options);
+
+    <T> CompletableFuture<T> call(
+            String procedure,
+            List<Object> args,
+            Class<T> resultType,
+            CallOptions options);
+
     /**
      * Calls a remote procedure.
      * @param procedure URI of the procedure to call
@@ -524,6 +598,28 @@ public interface ISession {
      * {@link io.crossbar.autobahn.wamp.types.CallResult}
      */
     CompletableFuture<CallResult> call(String procedure, Map<String, Object> kwargs);
+
+    <T> CompletableFuture<T> call(
+            String procedure,
+            Map<String, Object> kwargs,
+            TypeReference<T> resultType);
+
+    <T> CompletableFuture<T> call(
+            String procedure,
+            Map<String, Object> kwargs,
+            Class<T> resultType);
+
+    <T> CompletableFuture<T> call(
+            String procedure,
+            Map<String, Object> kwargs,
+            TypeReference<T> resultType,
+            CallOptions options);
+
+    <T> CompletableFuture<T> call(
+            String procedure,
+            Map<String, Object> kwargs,
+            Class<T> resultType,
+            CallOptions options);
 
     /**
      * Calls a remote procedure.
@@ -551,6 +647,16 @@ public interface ISession {
                                        Map<String, Object> kwargs,
                                        CallOptions options);
 
+    <T> CompletableFuture<T> call(String procedure,
+                                  List<Object> args,
+                                  Map<String, Object> kwargs,
+                                  TypeReference<T> resultType);
+
+    <T> CompletableFuture<T> call(String procedure,
+                                  List<Object> args,
+                                  Map<String, Object> kwargs,
+                                  Class<T> resultType);
+
     /**
      * Calls a remote procedure where the result needs to be resolved to a
      * POJO.
@@ -567,6 +673,12 @@ public interface ISession {
                                   List<Object> args,
                                   Map<String, Object> kwargs,
                                   TypeReference<T> resultType,
+                                  CallOptions options);
+
+    <T> CompletableFuture<T> call(String procedure,
+                                  List<Object> args,
+                                  Map<String, Object> kwargs,
+                                  Class<T> resultType,
                                   CallOptions options);
 
     /**

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/requests/CallRequest.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/requests/CallRequest.java
@@ -11,35 +11,31 @@
 
 package io.crossbar.autobahn.wamp.requests;
 
-import java.util.concurrent.CompletableFuture;
-
 import com.fasterxml.jackson.core.type.TypeReference;
 
+import java.util.concurrent.CompletableFuture;
+
 import io.crossbar.autobahn.wamp.types.CallOptions;
-import io.crossbar.autobahn.wamp.types.CallResult;
 
 
 public class CallRequest extends Request {
     public final String procedure;
     public final CallOptions options;
     public final CompletableFuture onReply;
-    public final TypeReference resultType;
+    public final TypeReference resultTypeRef;
+    public final Class resultTypeClass;
 
     public CallRequest(long request, String procedure, CompletableFuture onReply,
-                       CallOptions options) {
+                       CallOptions options, TypeReference resultTypeRef, Class resultTypeClass) {
         super(request);
         this.procedure = procedure;
         this.options = options;
         this.onReply = onReply;
-        this.resultType = null;
-    }
-
-    public CallRequest(long request, String procedure, CompletableFuture onReply,
-                       CallOptions options, TypeReference resultType) {
-        super(request);
-        this.procedure = procedure;
-        this.options = options;
-        this.onReply = onReply;
-        this.resultType = resultType;
+        if (resultTypeRef != null && resultTypeClass != null) {
+            throw new IllegalArgumentException(
+                    "Can only provide one of resultTypeRef or resultTypeClass");
+        }
+        this.resultTypeRef = resultTypeRef;
+        this.resultTypeClass = resultTypeClass;
     }
 }

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/requests/SubscribeRequest.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/requests/SubscribeRequest.java
@@ -21,15 +21,21 @@ import io.crossbar.autobahn.wamp.types.Subscription;
 public class SubscribeRequest extends Request {
     public final String topic;
     public final CompletableFuture<Subscription> onReply;
-    public final TypeReference resultType;
+    public final TypeReference resultTypeRef;
+    public final Class resultTypeClass;
     public final Object handler;
 
     public SubscribeRequest(long request, String topic, CompletableFuture<Subscription> onReply,
-                            TypeReference resultType, Object handler) {
+                            TypeReference resultTypeRef, Class resultTypeClass, Object handler) {
         super(request);
         this.topic = topic;
         this.onReply = onReply;
-        this.resultType = resultType;
+        if (resultTypeRef != null && resultTypeClass != null) {
+            throw new IllegalArgumentException(
+                    "Can only provide one of resultTypeRef or resultTypeClass");
+        }
+        this.resultTypeRef = resultTypeRef;
+        this.resultTypeClass = resultTypeClass;
         this.handler = handler;
     }
 }

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/types/Subscription.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/types/Subscription.java
@@ -16,13 +16,16 @@ import com.fasterxml.jackson.core.type.TypeReference;
 public class Subscription {
     public final long subscription;
     public final String topic;
-    public final TypeReference resultType;
+    public final TypeReference resultTypeRef;
+    public final Class resultTypeClass;
     public final Object handler;
 
-    public Subscription(long subscription, String topic, TypeReference resultType, Object handler) {
+    public Subscription(long subscription, String topic, TypeReference resultTypeRef,
+                        Class resultTypeClass, Object handler) {
         this.subscription = subscription;
         this.topic = topic;
-        this.resultType = resultType;
+        this.resultTypeRef = resultTypeRef;
+        this.resultTypeClass = resultTypeClass;
         this.handler = handler;
     }
 }

--- a/demo-gallery/src/main/java/io/crossbar/autobahn/demogallery/netty/Service.java
+++ b/demo-gallery/src/main/java/io/crossbar/autobahn/demogallery/netty/Service.java
@@ -66,7 +66,7 @@ public class Service {
 
         // call a remote procedure that returns a Person
         CompletableFuture<Void> f1 =
-            mSession.call("com.example.get_person", new TypeReference<Person>() {}, null)
+            mSession.call("com.example.get_person", Person.class)
                 .handleAsync(
                     (person, throwable) -> {
                         if (throwable != null) {
@@ -83,7 +83,7 @@ public class Service {
 
         // call a remote procedure that returns a Person .. slowly (3 secs delay)
         CompletableFuture<Void> f2 =
-            mSession.call("com.example.get_person_delayed", null, null, new TypeReference<Person>() {}, null)
+            mSession.call("com.example.get_person_delayed", Person.class)
                 .handleAsync(
                     (person, throwable) -> {
                         if (throwable != null) {
@@ -101,7 +101,7 @@ public class Service {
 
         // call a remote procedure that returns a List<Person>
         CompletableFuture<Void> f3 =
-            mSession.call("com.example.get_all_persons", null, null, new TypeReference<List<Person>>() {}, null)
+            mSession.call("com.example.get_all_persons", new TypeReference<List<Person>>() {})
                 .handleAsync(
                     (persons, throwable) -> {
                         if (throwable != null) {
@@ -124,7 +124,7 @@ public class Service {
         args.add("development");
 
         CompletableFuture<Void> f4 =
-            mSession.call("com.example.get_persons_by_department", args, null, new TypeReference<List<Person>>() {}, null)
+            mSession.call("com.example.get_persons_by_department", args, new TypeReference<List<Person>>() {})
                 .handleAsync(
                     (persons, throwable) -> {
                         if (throwable != null) {
@@ -145,7 +145,7 @@ public class Service {
 
         // call a remote procedure that returns a Map<String, List<Person>>
         CompletableFuture<Void> f5 =
-            mSession.call("com.example.get_persons_by_department", null, null, new TypeReference<Map<String, List<Person>>>() {}, null)
+            mSession.call("com.example.get_persons_by_department", new TypeReference<Map<String, List<Person>>>() {})
                 .handleAsync(
                     (Map<String, List<Person>> persons_by_department, Throwable throwable) -> {
                         if (throwable != null) {


### PR DESCRIPTION
This PR enables first class POJO support in our APIs. Previously we only supported TypeReference as a parameter, now we extend to support class references (e.g. String.class).