### PR TITLE
Revert Session.register() endpoint API removal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ java:
 		-it --rm --link crossbar \
 		-v ${shell pwd}:/workspace \
 		crossbario/autobahn-java:netty \
-			/bin/bash -c "gradle installDist -PbuildPlatform=netty && DEMO_GALLERY_OPTS="-DlogLevel=INFO" demo-gallery/build/install/demo-gallery/bin/demo-gallery ws://crossbar:8080/ws"
+			/bin/bash -c "gradle installDist -PbuildPlatform=netty && DEMO_GALLERY_OPTS="-DlogLevel=FINEST" demo-gallery/build/install/demo-gallery/bin/demo-gallery ws://crossbar:8080/ws"
 
 #
 # Build

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ java:
 		-it --rm --link crossbar \
 		-v ${shell pwd}:/workspace \
 		crossbario/autobahn-java:netty \
-			/bin/bash -c "gradle installDist -PbuildPlatform=netty && DEMO_GALLERY_OPTS="-DlogLevel=FINEST" demo-gallery/build/install/demo-gallery/bin/demo-gallery ws://crossbar:8080/ws"
+			/bin/bash -c "gradle installDist -PbuildPlatform=netty && DEMO_GALLERY_OPTS="-DlogLevel=INFO" demo-gallery/build/install/demo-gallery/bin/demo-gallery ws://crossbar:8080/ws"
 
 #
 # Build

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/Client.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/Client.java
@@ -97,10 +97,11 @@ public class Client {
     public CompletableFuture<ExitInfo> connect() {
         CompletableFuture<ExitInfo> exitFuture = new CompletableFuture<>();
         mSession.addOnConnectListener((session) ->
-                mSession.join(mRealm, null).thenAccept(details ->
+                mSession.join(mRealm).thenAccept(details ->
                         LOGGER.i(String.format("JOINED session=%s realm=%s", details.sessionID,
                                 details.realm))));
-        mSession.addOnDisconnectListener((session, wasClean) -> exitFuture.complete(new ExitInfo(wasClean)));
+        mSession.addOnDisconnectListener((session, wasClean) ->
+                exitFuture.complete(new ExitInfo(wasClean)));
         CompletableFuture.runAsync(() -> {
             try {
                 mTransports.get(0).connect(mSession);

--- a/demo-gallery/src/main/java/io/crossbar/autobahn/demogallery/netty/Main.java
+++ b/demo-gallery/src/main/java/io/crossbar/autobahn/demogallery/netty/Main.java
@@ -61,7 +61,7 @@ public class Main {
     }
 
     private static void readAndSetLogLevel() throws IOException {
-        String logLevel = System.getProperty("logLevel", "INFO");
+        String logLevel = System.getProperty("logLevel", "FINEST");
         String config = String.format(LOG_CONFIG, logLevel, logLevel);
         InputStream stream = new ByteArrayInputStream(config.getBytes(Charset.forName("UTF-8")));
         LogManager.getLogManager().readConfiguration(stream);


### PR DESCRIPTION
We briefly removed the endpoint's API that allowed it to return CompletableFuture<InvocationResult>, bringing it back.

Reference: https://github.com/crossbario/autobahn-java/pull/323