### PR TITLE
WAMP: implement ticket auth

### DIFF
--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/Client.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/Client.java
@@ -96,8 +96,11 @@ public class Client {
 
     public CompletableFuture<ExitInfo> connect() {
         CompletableFuture<ExitInfo> exitFuture = new CompletableFuture<>();
+        List<String> authMethods = new ArrayList<>();
+        authMethods.add("anonymous");
+        authMethods.add("ticket");
         mSession.addOnConnectListener((session) ->
-                mSession.join(mRealm).thenAccept(details ->
+                mSession.join(mRealm, authMethods).thenAccept(details ->
                         LOGGER.i(String.format("JOINED session=%s realm=%s", details.sessionID,
                                 details.realm))));
         mSession.addOnDisconnectListener((session, wasClean) ->

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/Client.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/Client.java
@@ -68,6 +68,14 @@ public class Client {
         mExecutor = executor;
     }
 
+    public Client(Session session, String webSocketURL, String realm,
+                  List<IAuthenticator> authenticators) {
+        this(webSocketURL);
+        mSession = session;
+        mRealm = realm;
+        mAuthenticators = authenticators;
+    }
+
     public Client(List<ITransport> transports) {
         mTransports = transports;
     }
@@ -96,11 +104,8 @@ public class Client {
 
     public CompletableFuture<ExitInfo> connect() {
         CompletableFuture<ExitInfo> exitFuture = new CompletableFuture<>();
-        List<String> authMethods = new ArrayList<>();
-        authMethods.add("anonymous");
-        authMethods.add("ticket");
         mSession.addOnConnectListener((session) ->
-                mSession.join(mRealm, authMethods).thenAccept(details ->
+                mSession.join(mRealm, mAuthenticators).thenAccept(details ->
                         LOGGER.i(String.format("JOINED session=%s realm=%s", details.sessionID,
                                 details.realm))));
         mSession.addOnDisconnectListener((session, wasClean) ->

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/auth/AnonymousAuth.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/auth/AnonymousAuth.java
@@ -23,12 +23,14 @@ public class AnonymousAuth implements IAuthenticator {
     public final String authmethod = "anonymous";
     public final String authid = null;
 
-    public AnonymousAuth () {
-    }
-
     public CompletableFuture<ChallengeResponse> onChallenge(Session session, Challenge challenge) {
         // anonymous authentication in WAMP will NOT invoke this callback!
         // FIXME
         return CompletableFuture.completedFuture(new ChallengeResponse(null, null));
+    }
+
+    @Override
+    public String getAuthMethod() {
+        return authmethod;
     }
 }

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/auth/TicketAuth.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/auth/TicketAuth.java
@@ -27,13 +27,18 @@ public class TicketAuth implements IAuthenticator {
     public final Map<String, Object> authextra;
     public final String ticket;
 
-    public TicketAuth (String authid, String ticket, Map<String, Object> authextra) {
+    public TicketAuth(String authid, String ticket, Map<String, Object> authextra) {
         this.authid = authid;
         this.ticket = ticket;
         this.authextra = authextra;
     }
 
     public CompletableFuture<ChallengeResponse> onChallenge(Session session, Challenge challenge) {
-        return CompletableFuture.completedFuture(new ChallengeResponse(this.ticket, this.authextra));
+        return CompletableFuture.completedFuture(new ChallengeResponse(ticket, authextra));
+    }
+
+    @Override
+    public String getAuthMethod() {
+        return authmethod;
     }
 }

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/interfaces/IAuthenticator.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/interfaces/IAuthenticator.java
@@ -19,5 +19,8 @@ import io.crossbar.autobahn.wamp.types.ChallengeResponse;
 
 
 public interface IAuthenticator {
+
     CompletableFuture<ChallengeResponse> onChallenge(Session session, Challenge challenge);
+
+    String getAuthMethod();
 }

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/interfaces/ISession.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/interfaces/ISession.java
@@ -23,10 +23,8 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 import io.crossbar.autobahn.wamp.Session;
-import io.crossbar.autobahn.wamp.types.Challenge;
 import io.crossbar.autobahn.wamp.types.CallOptions;
 import io.crossbar.autobahn.wamp.types.CallResult;
-import io.crossbar.autobahn.wamp.types.ChallengeResponse;
 import io.crossbar.autobahn.wamp.types.CloseDetails;
 import io.crossbar.autobahn.wamp.types.EventDetails;
 import io.crossbar.autobahn.wamp.types.InvocationDetails;
@@ -711,11 +709,11 @@ public interface ISession {
     /**
      * Joins a realm on the WAMP router
      * @param realm name of the realm to join
-     * @param authMethods list of authentication methods to try
+     * @param authenticators list of authentication methods to try
      * @return a CompletableFuture that resolves to an instance of
      * {@link io.crossbar.autobahn.wamp.types.SessionDetails}
      */
-    CompletableFuture<SessionDetails> join(String realm, List<String> authMethods);
+    CompletableFuture<SessionDetails> join(String realm, List<IAuthenticator> authenticators);
 
     /**
      * Leaves the currently joined WAMP session.
@@ -760,9 +758,5 @@ public interface ISession {
     // FIXME: come up with an equivalent of txaio.IFailedFuture as first arg.
     interface OnUserErrorListener {
         void onUserError(Session session, String message);
-    }
-
-    interface OnChallengeListener {
-        ChallengeResponse onChallenge(Challenge challenge);
     }
 }

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/interfaces/ISession.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/interfaces/ISession.java
@@ -23,8 +23,10 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 import io.crossbar.autobahn.wamp.Session;
+import io.crossbar.autobahn.wamp.types.Challenge;
 import io.crossbar.autobahn.wamp.types.CallOptions;
 import io.crossbar.autobahn.wamp.types.CallResult;
+import io.crossbar.autobahn.wamp.types.ChallengeResponse;
 import io.crossbar.autobahn.wamp.types.CloseDetails;
 import io.crossbar.autobahn.wamp.types.EventDetails;
 import io.crossbar.autobahn.wamp.types.InvocationDetails;
@@ -758,5 +760,9 @@ public interface ISession {
     // FIXME: come up with an equivalent of txaio.IFailedFuture as first arg.
     interface OnUserErrorListener {
         void onUserError(Session session, String message);
+    }
+
+    interface OnChallengeListener {
+        ChallengeResponse onChallenge(Challenge challenge);
     }
 }

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Authenticate.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Authenticate.java
@@ -12,6 +12,7 @@
 package io.crossbar.autobahn.wamp.messages;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -40,7 +41,11 @@ public class Authenticate implements IMessage {
         List<Object> marshaled = new ArrayList<>();
         marshaled.add(MESSAGE_TYPE);
         marshaled.add(signature);
-        marshaled.add(extra);
+        if (extra == null) {
+            marshaled.add(new HashMap<>());
+        } else {
+            marshaled.add(extra);
+        }
         return marshaled;
     }
 }

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Hello.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Hello.java
@@ -19,12 +19,16 @@ import java.util.Map;
 import io.crossbar.autobahn.wamp.interfaces.IMessage;
 import io.crossbar.autobahn.wamp.utils.MessageUtil;
 
+import static io.crossbar.autobahn.wamp.utils.Shortcuts.getOrDefault;
+
 public class Hello implements IMessage {
 
     public static final int MESSAGE_TYPE = 1;
 
     public final String realm;
     public final Map<String, Map> roles;
+    public final List<String> authMethods;
+    public final String authID;
 
     @Override
     public List<Object> marshal() {
@@ -33,6 +37,12 @@ public class Hello implements IMessage {
         marshaled.add(realm);
         Map<String, Object> details = new HashMap<>();
         details.put("roles", roles);
+        if (authMethods != null) {
+            details.put("authmethods", authMethods);
+        }
+        if (authID != null) {
+            details.put("authid", authID);
+        }
         marshaled.add(details);
         return marshaled;
     }
@@ -44,12 +54,20 @@ public class Hello implements IMessage {
 
         Map<String, Object> details = (Map<String, Object>) wmsg.get(2);
         Map<String, Map> roles = (Map<String, Map>) details.get("roles");
+        List<String> authMethods = getOrDefault(details, "authmethods", null);
+        String authID = getOrDefault(details, "authid", null);
 
-        return new Hello(realm, roles);
+        return new Hello(realm, roles, authMethods, authID);
     }
 
     public Hello(String realm, Map<String, Map> roles) {
+        this(realm, roles, null, null);
+    }
+
+    public Hello(String realm, Map<String, Map> roles, List<String> authMethods, String authID) {
         this.realm = realm;
         this.roles = roles;
+        this.authMethods = authMethods;
+        this.authID = authID;
     }
 }

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/MessageMap.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/MessageMap.java
@@ -21,6 +21,7 @@ public class MessageMap {
 
     static {
         MESSAGE_TYPE_MAP.put(Hello.MESSAGE_TYPE, Hello.class);
+        MESSAGE_TYPE_MAP.put(Challenge.MESSAGE_TYPE, Challenge.class);
         MESSAGE_TYPE_MAP.put(Welcome.MESSAGE_TYPE, Welcome.class);
         MESSAGE_TYPE_MAP.put(Abort.MESSAGE_TYPE, Abort.class);
         MESSAGE_TYPE_MAP.put(Goodbye.MESSAGE_TYPE, Goodbye.class);


### PR DESCRIPTION
This _works_ but needs an API review from @oberstet, I still need to extend the Session.join() to accept sessionID as a parameter as well.

Also need to define the API through which the user code returns a ChallengeResponse, with the current proposed version, the developer must add a `onChallengeListener` to the Session class with method `setOnChallengeListener`.