### PR TITLE
Reflection-based roles

### DIFF
--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/reflectionRoles/ArgumentUnpacker.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/reflectionRoles/ArgumentUnpacker.java
@@ -1,0 +1,51 @@
+package io.crossbar.autobahn.wamp.reflectionRoles;
+
+import io.crossbar.autobahn.wamp.interfaces.ISerializer;
+
+import java.lang.reflect.Parameter;
+import java.util.List;
+import java.util.Map;
+
+public class ArgumentUnpacker {
+    private final ParameterInfo[] mParameters;
+
+    public ArgumentUnpacker(Parameter[] parameters) {
+        mParameters = new ParameterInfo[parameters.length];
+
+        for (int i = 0; i < parameters.length; i++) {
+            Parameter parameter = parameters[i];
+            String parameterName = parameter.getName();
+            Class<?> parameterType = parameter.getType();
+            mParameters[i] = new ParameterInfo(i, parameterName, parameterType);
+        }
+    }
+
+    public Object[] unpackParameters(ISerializer serializer, List<Object> list, Map<String, Object> map){
+        Object[] result = new Object[mParameters.length];
+
+        // Positional arguments have higher precedence.
+        for (int i = 0; i < list.size(); i++) {
+            // TODO: surround with a try-catch block and throw a WampException indicating that the
+            // TODO: parameter at position i wasn't of the expected type.
+            result[i] = serializer.convertValue(list.get(i), mParameters[i].getType());
+        }
+
+        for (int i = list.size(); i < mParameters.length; i++){
+            ParameterInfo currentParameter = mParameters[i];
+
+            String parameterName = currentParameter.getName();
+
+            if (!map.containsKey(parameterName)) {
+                // TODO: throw a WampException indicating that a
+                // TODO: parameter with name parameterName or position i was not present.
+            } else {
+                // TODO: surround with a try-catch block and throw a WampException indicating that the
+                // TODO: parameter with name parameterName wasn't of the expected type.
+                result[i] = serializer.convertValue(map.get(parameterName), currentParameter.getType());
+            }
+        }
+
+        return result;
+    }
+}
+

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/reflectionRoles/CalleeProxyInvocationHandler.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/reflectionRoles/CalleeProxyInvocationHandler.java
@@ -1,0 +1,74 @@
+package io.crossbar.autobahn.wamp.reflectionRoles;
+
+import io.crossbar.autobahn.wamp.Session;
+import io.crossbar.autobahn.wamp.reflectionRoles.WampProcedure;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+public class CalleeProxyInvocationHandler implements InvocationHandler {
+
+    private final Session mSession;
+
+    public CalleeProxyInvocationHandler(Session session) {
+        this.mSession = session;
+    }
+
+    @Override
+    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+        if (method.getReturnType() == CompletableFuture.class) {
+            return handleAsync(method, args);
+        } else {
+            return handleSync(method, args);
+        }
+    }
+
+    public Object handleSync(Method method, Object[] args) {
+        try {
+            CompletableFuture<?> task =
+                    innerHandleAsync(method,
+                            args,
+                            method.getReturnType());
+
+            return task.get();
+        } catch (ExecutionException ex) {
+            Throwable cause = ex.getCause();
+
+            if (cause instanceof RuntimeException) {
+                throw ((RuntimeException) cause);
+            } else {
+                throw new RuntimeException(cause.getMessage(), cause);
+            }
+        } catch (RuntimeException ex) {
+            throw ex;
+        } catch (Exception ex) {
+            throw new RuntimeException(ex.getMessage(), ex);
+        }
+    }
+
+    public Object handleAsync(Method method, Object[] args) {
+        Type taskType = method.getGenericReturnType();
+        Class<?> returnType = getTaskGenericParameterType(taskType);
+
+        return innerHandleAsync(method, args, returnType);
+    }
+
+    private Class<?> getTaskGenericParameterType(Type taskType) {
+        Class<?> result = (Class<?>) ((ParameterizedType) taskType).getActualTypeArguments()[0];
+        return result;
+    }
+
+    private CompletableFuture<?> innerHandleAsync(Method method, Object[] args, Class<?> returnType) {
+        WampProcedure annotation = method.getAnnotation(WampProcedure.class);
+        String procedureUri = annotation.value();
+
+        CompletableFuture<?> result = this.mSession.call(procedureUri, Arrays.asList(args), returnType);
+
+        return result;
+    }
+}

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/reflectionRoles/MethodEventHandler.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/reflectionRoles/MethodEventHandler.java
@@ -1,0 +1,34 @@
+package io.crossbar.autobahn.wamp.reflectionRoles;
+
+import io.crossbar.autobahn.wamp.interfaces.ISerializer;
+import io.crossbar.autobahn.wamp.interfaces.TriConsumer;
+import io.crossbar.autobahn.wamp.types.EventDetails;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Map;
+
+public class MethodEventHandler implements TriConsumer<List<Object>, Map<String, Object>, EventDetails> {
+
+    private final Object mInstance;
+    private final ArgumentUnpacker mUnpacker;
+    private final ISerializer mSerializer;
+    private final Method mMethod;
+
+    public MethodEventHandler(Object instance, Method method, ISerializer serializer) {
+        this.mInstance = instance;
+        this.mMethod = method;
+        this.mUnpacker = new ArgumentUnpacker(method.getParameters());
+        this.mSerializer = serializer;
+    }
+    @Override
+    public void accept(List<Object> args, Map<String, Object> kwargs, EventDetails details) {
+        try {
+            Object[] parameters = this.mUnpacker.unpackParameters(this.mSerializer, args, kwargs);
+            this.mMethod.invoke(this.mInstance, parameters);
+        }
+        catch (Throwable ex){
+            // TODO: deal with exception
+        }
+    }
+}

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/reflectionRoles/MethodInvocationHandler.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/reflectionRoles/MethodInvocationHandler.java
@@ -21,7 +21,6 @@ public class MethodInvocationHandler implements IInvocationHandler {
         this.mInstance = instance;
         this.mMethod = method;
         this.mUnpacker = new ArgumentUnpacker(method.getParameters());
-        // TODO: the serializer should be passed by AutobahnJava somehow.
         this.mSerializer = serializer;
     }
 

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/reflectionRoles/MethodInvocationHandler.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/reflectionRoles/MethodInvocationHandler.java
@@ -1,0 +1,57 @@
+package io.crossbar.autobahn.wamp.reflectionRoles;
+
+import io.crossbar.autobahn.wamp.interfaces.IInvocationHandler;
+import io.crossbar.autobahn.wamp.interfaces.ISerializer;
+import io.crossbar.autobahn.wamp.types.InvocationDetails;
+import io.crossbar.autobahn.wamp.types.InvocationResult;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Map;
+
+public class MethodInvocationHandler implements IInvocationHandler {
+
+    private final Object mInstance;
+    private final ArgumentUnpacker mUnpacker;
+    private final ISerializer mSerializer;
+    private final Method mMethod;
+
+    public MethodInvocationHandler(Object instance, Method method, ISerializer serializer) {
+        this.mInstance = instance;
+        this.mMethod = method;
+        this.mUnpacker = new ArgumentUnpacker(method.getParameters());
+        // TODO: the serializer should be passed by AutobahnJava somehow.
+        this.mSerializer = serializer;
+    }
+
+    @Override
+    public InvocationResult apply(List<Object> list, Map<String, Object> map, InvocationDetails invocationDetails) {
+        Object[] parameters = this.mUnpacker.unpackParameters(this.mSerializer, list, map);
+
+        try
+        {
+            Object result = this.mMethod.invoke(mInstance, parameters);
+            return new InvocationResult(result);
+        }
+        catch (Exception e){
+            if (e instanceof InvocationTargetException){
+                InvocationTargetException casted = (InvocationTargetException) e;
+                Throwable targetException = casted.getTargetException();
+                Throwable convertedException = convertRuntimeException(targetException);
+                // TODO: throw convertedException
+                // TODO: It is currently not possible to throw an exception from this interface.
+            }
+        }
+
+        return new InvocationResult((Object)null);
+    }
+
+    private Throwable convertRuntimeException(Throwable targetException) {
+        if (targetException instanceof WampException){
+            return targetException;
+        }
+
+        return new WampException("wamp.error.runtime_error", targetException.getMessage());
+    }
+}

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/reflectionRoles/ParameterInfo.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/reflectionRoles/ParameterInfo.java
@@ -1,0 +1,25 @@
+package io.crossbar.autobahn.wamp.reflectionRoles;
+
+public class ParameterInfo{
+    private final int mPosition;
+    private final String mName;
+    private final Class<?> mType;
+
+    public ParameterInfo(int position, String name, Class<?> type) {
+        this.mPosition = position;
+        this.mName = name;
+        this.mType = type;
+    }
+
+    public int getPosition() {
+        return mPosition;
+    }
+
+    public String getName() {
+        return mName;
+    }
+
+    public Class<?> getType() {
+        return mType;
+    }
+}

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/reflectionRoles/ReflectionServices.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/reflectionRoles/ReflectionServices.java
@@ -1,0 +1,53 @@
+package io.crossbar.autobahn.wamp.reflectionRoles;
+
+import io.crossbar.autobahn.wamp.Session;
+import io.crossbar.autobahn.wamp.interfaces.ISerializer;
+import io.crossbar.autobahn.wamp.types.Registration;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+public class ReflectionServices {
+    private final Session mSession;
+    private final ISerializer mSerializer;
+
+    public ReflectionServices(Session session, ISerializer serializer){
+        mSession = session;
+        mSerializer = serializer;
+    }
+
+    public List<CompletableFuture<Registration>> registerCallee(Object instance) {
+        List<CompletableFuture<Registration>> registrations = new ArrayList<CompletableFuture<Registration>>();
+        Class<?> classType = instance.getClass();
+
+        for (Method method : classType.getMethods()) {
+            if (method.isAnnotationPresent(WampProcedure.class)) {
+                WampProcedure anotation = method.getAnnotation(WampProcedure.class);
+
+                MethodInvocationHandler currentMethodHandler =
+                        new MethodInvocationHandler(instance, method, this.mSerializer);
+
+                CompletableFuture<Registration> currentRegistration =
+                        mSession.register(anotation.value(), currentMethodHandler);
+
+                registrations.add(currentRegistration);
+            }
+        }
+
+        return registrations;
+    }
+
+    public <TProxy> TProxy getCalleeProxy(Class<TProxy> proxyClass) {
+        // TODO: check the current type is valid for proxy.
+        TProxy result =
+                (TProxy)
+                        Proxy.newProxyInstance(proxyClass.getClassLoader(),
+                                new Class[]{proxyClass},
+                                new CalleeProxyInvocationHandler(this.mSession));
+
+        return result;
+    }
+}

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/reflectionRoles/WampException.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/reflectionRoles/WampException.java
@@ -1,0 +1,42 @@
+package io.crossbar.autobahn.wamp.reflectionRoles;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+public class WampException extends Exception {
+    private final String mErrorUri;
+    private final Map<String, Object> mDetails;
+    private final List<Object> mArguments;
+    private final Map<String, Object> mKwArguments;
+
+    public WampException(String errorUri, Object... arguments) {
+        this.mErrorUri = errorUri;
+        this.mDetails = null;
+        this.mArguments = Arrays.asList(arguments);
+        this.mKwArguments = null;
+    }
+
+    public WampException(String errorUri, Map<String, Object> details, List<Object> arguments, Map<String, Object> kwArguments) {
+        this.mErrorUri = errorUri;
+        this.mDetails = details;
+        this.mArguments = arguments;
+        this.mKwArguments = kwArguments;
+    }
+
+    public String getErrorUri() {
+        return mErrorUri;
+    }
+
+    public Map<String, Object> getDetails() {
+        return mDetails;
+    }
+
+    public List<Object> getArguments() {
+        return mArguments;
+    }
+
+    public Map<String, Object> getKwArguments() {
+        return mKwArguments;
+    }
+}

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/reflectionRoles/WampProcedure.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/reflectionRoles/WampProcedure.java
@@ -1,0 +1,12 @@
+package io.crossbar.autobahn.wamp.reflectionRoles;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD) //can use in method only.
+public @interface WampProcedure {
+    String value();
+}

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/reflectionRoles/WampTopic.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/reflectionRoles/WampTopic.java
@@ -1,0 +1,12 @@
+package io.crossbar.autobahn.wamp.reflectionRoles;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD) //can use in method only.
+public @interface WampTopic {
+    String value();
+}


### PR DESCRIPTION
Hi @oberstet,

This pull request contains a sketch for reflection based caller/callee roles. This is pretty cool.

## Usage:

### Callee proxy:
Declare an interface:

```java
import io.crossbar.autobahn.wamp.reflectionRoles.WampProcedure;

import java.util.concurrent.CompletableFuture;

public interface IMulCalculator {
    @WampProcedure("com.example.mul2")
    CompletableFuture<Integer> mulAsync(int x, int y);

    @WampProcedure("com.example.mul2")
    int mulSync(int x, int y);
}
```

Use ReflectionServices property of session in order to obtain a proxy, and then call the desired method:

```java
import io.crossbar.autobahn.wamp.Client;
import io.crossbar.autobahn.wamp.Session;
import io.crossbar.autobahn.wamp.interfaces.IInvocationHandler;
import io.crossbar.autobahn.wamp.reflectionRoles.ReflectionServices;
import io.crossbar.autobahn.wamp.reflectionRoles.WampProcedure;
import io.crossbar.autobahn.wamp.serializers.JSONSerializer;
import io.crossbar.autobahn.wamp.types.ExitInfo;
import io.crossbar.autobahn.wamp.types.InvocationDetails;
import io.crossbar.autobahn.wamp.types.InvocationResult;

import java.lang.reflect.Method;
import java.util.List;
import java.util.Map;
import java.util.concurrent.CompletableFuture;
import java.util.concurrent.Executor;
import java.util.concurrent.Executors;

public class Main {

    public static void main(String[] args) {
        Executor executor = Executors.newSingleThreadExecutor();

        Session mySession = new Session();

        mySession.addOnJoinListener((session, sessionDetails) -> {
            System.out.println("Connected!");

            ReflectionServices reflectionServices = mySession.getReflectionServices();

            // Call obtain a callee-proxy.
            IMulCalculator calleeProxy = reflectionServices.getCalleeProxy(IMulCalculator.class);

            // Call "com.example.mul2".
            int sixtyThree = calleeProxy.mulSync(3, 21);
        });

        // finally, provide everything to a Client and connect
        Client client = new Client(mySession, "ws://127.0.0.1:8080/ws", "realm1", executor);

        CompletableFuture<ExitInfo> exitInfoCompletableFuture = client.connect();
    }
}
```

### Callee

Declare a class

```java
import io.crossbar.autobahn.wamp.reflectionRoles.WampProcedure;

public class AddCalculator {
    @WampProcedure("com.example.add2")
    public int add(int x, int y){
        return (x+y);
    }
}
```

Use ReflectionServices property of service to register all procedures of an instance of this class:

```java
import io.crossbar.autobahn.wamp.Client;
import io.crossbar.autobahn.wamp.Session;
import io.crossbar.autobahn.wamp.interfaces.IInvocationHandler;
import io.crossbar.autobahn.wamp.reflectionRoles.ReflectionServices;
import io.crossbar.autobahn.wamp.reflectionRoles.WampProcedure;
import io.crossbar.autobahn.wamp.serializers.JSONSerializer;
import io.crossbar.autobahn.wamp.types.ExitInfo;
import io.crossbar.autobahn.wamp.types.InvocationDetails;
import io.crossbar.autobahn.wamp.types.InvocationResult;

import java.lang.reflect.Method;
import java.util.List;
import java.util.Map;
import java.util.concurrent.CompletableFuture;
import java.util.concurrent.Executor;
import java.util.concurrent.Executors;

public class Main {

    public static void main(String[] args) {
        Executor executor = Executors.newSingleThreadExecutor();

        Session mySession = new Session();

        mySession.addOnJoinListener((session, sessionDetails) -> {
            System.out.println("Connected!");

            ReflectionServices reflectionServices = mySession.getReflectionServices();

            // Register "com.example.add2"
            reflectionServices.registerCallee(new AddCalculator());
        });


        // finally, provide everything to a Client and connect
        Client client = new Client(mySession, "ws://127.0.0.1:8080/ws", "realm1", executor);

        CompletableFuture<ExitInfo> exitInfoCompletableFuture = client.connect();
    }
}
```

## TODOs

* I also added the WampException class, which should allow users to throw their own WAMP ERRORs. Unfortunately, the IInvocationHandler interface does not allow methods to throw exceptions, so this is currently unusable.
* You would probably want to add support for async methods (methods that return a CompletableFuture) for the callee role - I didn't support this, since IInvocationHandler currently only returns InvocationResult.
* When deserialization fails, or a parameter is missing, you should throw an appropriate WampException indicating which parameter is missing/isn't of the requested type.
* Deserialization of parameter by names doesn't work by default. This is because Java omits parameter names from compilation by default. This does work when adding the -parameters flag to the Java compiler (this should be done by the application code). See [here](https://stackoverflow.com/questions/2237803/can-i-obtain-method-parameter-name-using-java-reflection).

I really hope that this kind of feature will be integrated in AutobahnJava.
Feel free to ask me any question about this.

Elad