### PR TITLE
Disable ReflectionRoles API for Android < 26

### DIFF
--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/Session.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/Session.java
@@ -107,8 +107,6 @@ public class Session implements ISession, ITransportHandler {
     private final int STATE_GOODBYE_SENT = 6;
     private final int STATE_ABORT_SENT = 7;
 
-    private final boolean REFLECTION_ROLES_SUPPORTED;
-
     private ITransport mTransport;
     private ISerializer mSerializer;
     private Executor mExecutor;
@@ -153,9 +151,6 @@ public class Session implements ISession, ITransportHandler {
         mRegistrations = new HashMap<>();
         mUnsubscribeRequests = new HashMap<>();
         mUnregisterRequests = new HashMap<>();
-        // ReflectionServices requires Android 8.0+ (API level 26) because of its dependency
-        // on some Java8 features.
-        REFLECTION_ROLES_SUPPORTED = !Platform.isAndroid() || Platform.getAndroidAPIVersion() >= 26;
     }
 
     public Session(Executor executor) {
@@ -189,10 +184,7 @@ public class Session implements ISession, ITransportHandler {
         }
         mTransport = transport;
         mSerializer = serializer;
-
-        if (REFLECTION_ROLES_SUPPORTED) {
-            mReflectionServices = new ReflectionServices(this, mSerializer);
-        }
+        mReflectionServices = new ReflectionServices(this, mSerializer);
 
         runAsync(() -> {
             for (OnConnectListener listener: mOnConnectListeners) {
@@ -1365,9 +1357,6 @@ public class Session implements ISession, ITransportHandler {
     }
 
     public ReflectionServices getReflectionServices() {
-        if (!REFLECTION_ROLES_SUPPORTED) {
-            throw new RuntimeException("Service only supported on non-Android systems for now");
-        }
         return mReflectionServices;
     }
 }

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/reflectionRoles/ArgumentUnpacker.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/reflectionRoles/ArgumentUnpacker.java
@@ -1,7 +1,9 @@
 package io.crossbar.autobahn.wamp.reflectionRoles;
 
 import io.crossbar.autobahn.wamp.interfaces.ISerializer;
+import io.crossbar.autobahn.wamp.utils.Platform;
 
+import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 import java.util.List;
 import java.util.Map;
@@ -9,14 +11,26 @@ import java.util.Map;
 public class ArgumentUnpacker {
     private final ParameterInfo[] mParameters;
 
-    public ArgumentUnpacker(Parameter[] parameters) {
-        mParameters = new ParameterInfo[parameters.length];
+    public ArgumentUnpacker(Method method) {
 
-        for (int i = 0; i < parameters.length; i++) {
-            Parameter parameter = parameters[i];
-            String parameterName = parameter.getName();
-            Class<?> parameterType = parameter.getType();
-            mParameters[i] = new ParameterInfo(i, parameterName, parameterType);
+        if (!Platform.isAndroid() || Platform.getAndroidAPIVersion() >= 26) {
+            Parameter[] parameters = method.getParameters();
+            mParameters = new ParameterInfo[parameters.length];
+            for (int i = 0; i < parameters.length; i++) {
+                Parameter parameter = parameters[i];
+                String parameterName = parameter.getName();
+                Class<?> parameterType = parameter.getType();
+                mParameters[i] = new ParameterInfo(i, parameterName, parameterType);
+            }
+        } else {
+            Class<?>[] parameterTypes = method.getParameterTypes();
+            mParameters = new ParameterInfo[parameterTypes.length];
+
+            for (int i = 0; i < parameterTypes.length; i++) {
+                String parameterName = "arg" + i;
+                Class<?> parameterType = parameterTypes[i];
+                mParameters[i] = new ParameterInfo(i, parameterName, parameterType);
+            }
         }
     }
 

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/reflectionRoles/MethodEventHandler.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/reflectionRoles/MethodEventHandler.java
@@ -21,6 +21,7 @@ public class MethodEventHandler implements TriConsumer<List<Object>, Map<String,
         this.mUnpacker = new ArgumentUnpacker(method.getParameters());
         this.mSerializer = serializer;
     }
+
     @Override
     public void accept(List<Object> args, Map<String, Object> kwargs, EventDetails details) {
         try {

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/reflectionRoles/MethodEventHandler.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/reflectionRoles/MethodEventHandler.java
@@ -18,7 +18,7 @@ public class MethodEventHandler implements TriConsumer<List<Object>, Map<String,
     public MethodEventHandler(Object instance, Method method, ISerializer serializer) {
         this.mInstance = instance;
         this.mMethod = method;
-        this.mUnpacker = new ArgumentUnpacker(method.getParameters());
+        this.mUnpacker = new ArgumentUnpacker(method);
         this.mSerializer = serializer;
     }
 

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/reflectionRoles/MethodInvocationHandler.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/reflectionRoles/MethodInvocationHandler.java
@@ -20,7 +20,7 @@ public class MethodInvocationHandler implements IInvocationHandler {
     public MethodInvocationHandler(Object instance, Method method, ISerializer serializer) {
         this.mInstance = instance;
         this.mMethod = method;
-        this.mUnpacker = new ArgumentUnpacker(method.getParameters());
+        this.mUnpacker = new ArgumentUnpacker(method);
         this.mSerializer = serializer;
     }
 

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/utils/Platform.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/utils/Platform.java
@@ -18,6 +18,9 @@ import io.crossbar.autobahn.wamp.interfaces.ITransport;
 
 public class Platform {
 
+    private static boolean IS_PLATFORM_CHECKED = false;
+    private static boolean IS_ANDROID = false;
+
     /**
      * Checks if code is running on Android.
      *
@@ -25,7 +28,29 @@ public class Platform {
      *     is Android based
      */
     public static boolean isAndroid() {
-        return System.getProperty("java.vendor").equals("The Android Project");
+        if (!IS_PLATFORM_CHECKED) {
+            IS_ANDROID = System.getProperty("java.vendor").equals("The Android Project");
+            IS_PLATFORM_CHECKED = true;
+        }
+        return IS_ANDROID;
+    }
+
+    /**
+     * Checks if the underlying platform is Android and if the
+     * API level is greater than equal to the requested value.
+     *
+     * Returns 0 if the platform is not Android.
+     */
+    public static int getAndroidAPIVersion() {
+        if (isAndroid()) {
+            try {
+                Class<?> klass = Class.forName("android.os.Build$VERSION");
+                return klass.getField("SDK_INT").getInt(null);
+            } catch (ClassNotFoundException | NoSuchFieldException | IllegalAccessException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return 0;
     }
 
     /**


### PR DESCRIPTION
As discussed previously ReflectionRoles API is dependent on some Java8 features that are only available in Android 8.0+ aka API level 26. Lets "disable" it.

* Minor optimization to platform query code