### PR TITLE
Allow settings TLS protocols in WebSocket options

### DIFF
--- a/autobahn/src/main/java/io/crossbar/autobahn/websocket/WebSocketConnection.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/websocket/WebSocketConnection.java
@@ -125,8 +125,8 @@ public class WebSocketConnection implements IWebSocket {
                     mSocket = SocketFactory.getDefault().createSocket();
                 }
 
-                if (mOptions.getEnableTls()){
-                    enableTLSOnSocket(mSocket);
+                if (mOptions.getTLSEnabledProtocols() != null){
+                    setEnabledProtocolsOnSSLSocket(mSocket, mOptions.getTLSEnabledProtocols());
                 }
 
                 // the following will block until connection was established or
@@ -681,12 +681,13 @@ public class WebSocketConnection implements IWebSocket {
     }
 
     /**
-     * Enable TLS manually on socket. It's basically need for android api level < 20.
+     * Enable protocols on SSLSocket.
      * @param socket
+     * @param protocols
      */
-    private void enableTLSOnSocket(Socket socket) {
+    private void setEnabledProtocolsOnSSLSocket(Socket socket, String[] protocols) {
         if(socket != null && (socket instanceof SSLSocket)) {
-            ((SSLSocket)socket).setEnabledProtocols(new String[] {"TLSv1.1", "TLSv1.2"});
+            ((SSLSocket)socket).setEnabledProtocols(protocols);
         }
     }
 }

--- a/autobahn/src/main/java/io/crossbar/autobahn/websocket/WebSocketConnection.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/websocket/WebSocketConnection.java
@@ -28,6 +28,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import javax.net.SocketFactory;
+import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
 
 import io.crossbar.autobahn.utils.ABLogger;
@@ -122,6 +123,10 @@ public class WebSocketConnection implements IWebSocket {
                     mSocket = SSLSocketFactory.getDefault().createSocket();
                 } else {
                     mSocket = SocketFactory.getDefault().createSocket();
+                }
+
+                if (mOptions.getEnableTls()){
+                    enableTLSOnSocket(mSocket);
                 }
 
                 // the following will block until connection was established or
@@ -673,5 +678,15 @@ public class WebSocketConnection implements IWebSocket {
         mReader.start();
 
         LOGGER.d("WS reader created and started");
+    }
+
+    /**
+     * Enable TLS manually on socket. It's basically need for android api level < 20.
+     * @param socket
+     */
+    private void enableTLSOnSocket(Socket socket) {
+        if(socket != null && (socket instanceof SSLSocket)) {
+            ((SSLSocket)socket).setEnabledProtocols(new String[] {"TLSv1.1", "TLSv1.2"});
+        }
     }
 }

--- a/autobahn/src/main/java/io/crossbar/autobahn/websocket/types/WebSocketOptions.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/websocket/types/WebSocketOptions.java
@@ -28,6 +28,7 @@ public class WebSocketOptions {
     private boolean mValidateIncomingUtf8;
     private boolean mMaskClientFrames;
     private int mReconnectInterval;
+    private boolean mEnableTls;
 
 
     /**
@@ -44,6 +45,7 @@ public class WebSocketOptions {
         mValidateIncomingUtf8 = true;
         mMaskClientFrames = true;
         mReconnectInterval = 0;  // no reconnection by default
+        mEnableTls = false;
     }
 
     /**
@@ -62,6 +64,7 @@ public class WebSocketOptions {
         mValidateIncomingUtf8 = other.mValidateIncomingUtf8;
         mMaskClientFrames = other.mMaskClientFrames;
         mReconnectInterval = other.mReconnectInterval;
+        mEnableTls = other.mEnableTls;
     }
 
     /**
@@ -261,5 +264,13 @@ public class WebSocketOptions {
 
     public int getReconnectInterval() {
         return mReconnectInterval;
+    }
+
+    public boolean getEnableTls() {
+        return mEnableTls;
+    }
+
+    public void setEnableTls(boolean enable) {
+        this.mEnableTls = enable;
     }
 }

--- a/autobahn/src/main/java/io/crossbar/autobahn/websocket/types/WebSocketOptions.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/websocket/types/WebSocketOptions.java
@@ -28,7 +28,7 @@ public class WebSocketOptions {
     private boolean mValidateIncomingUtf8;
     private boolean mMaskClientFrames;
     private int mReconnectInterval;
-    private boolean mEnableTls;
+    private String[] mTlsProtocols;
 
 
     /**
@@ -45,7 +45,7 @@ public class WebSocketOptions {
         mValidateIncomingUtf8 = true;
         mMaskClientFrames = true;
         mReconnectInterval = 0;  // no reconnection by default
-        mEnableTls = false;
+        mTlsProtocols = null;
     }
 
     /**
@@ -64,7 +64,7 @@ public class WebSocketOptions {
         mValidateIncomingUtf8 = other.mValidateIncomingUtf8;
         mMaskClientFrames = other.mMaskClientFrames;
         mReconnectInterval = other.mReconnectInterval;
-        mEnableTls = other.mEnableTls;
+        mTlsProtocols = other.mTlsProtocols;
     }
 
     /**
@@ -266,11 +266,19 @@ public class WebSocketOptions {
         return mReconnectInterval;
     }
 
-    public boolean getEnableTls() {
-        return mEnableTls;
+    /**
+     * Get TLS enabled protocols.
+     * @return
+     */
+    public String[] getTLSEnabledProtocols() {
+        return mTlsProtocols;
     }
 
-    public void setEnableTls(boolean enable) {
-        this.mEnableTls = enable;
+    /**
+     * Set TLS enabled protocols. Eg. protocols = new String[]{"TLSv1.1", "TLSv1.2"}
+     * @param protocols
+     */
+    public void setTLSEnabledProtocols(String[] protocols) {
+        this.mTlsProtocols = protocols;
     }
 }


### PR DESCRIPTION
For android API level < 20, TLSv1.2 doesn't support by default. To enable TLSv1.1 and TLSv1.2 we need to enable TLS on socket.

How to use:
```
WebSocketConnection webSocketConnection = new WebSocketConnection();
WebSocketOptions options = new WebSocketOptions();
options.setEnableTls(true);
webSocketConnection.connect(SERVER_URL, handler, options);
```