### PR TITLE
Extend WAMP transports to be configurable

### DIFF
--- a/autobahn/build.gradle
+++ b/autobahn/build.gradle
@@ -63,11 +63,11 @@ bintray {
 
 if (project.IS_ANDROID) {
     android {
-        compileSdkVersion 26
-        buildToolsVersion '26.0.2'
+        compileSdkVersion 27
+        buildToolsVersion '27.0.3'
         defaultConfig {
             minSdkVersion 24
-            targetSdkVersion 26
+            targetSdkVersion 27
         }
         buildTypes {
             release {

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/interfaces/ITransport.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/interfaces/ITransport.java
@@ -11,11 +11,15 @@
 
 package io.crossbar.autobahn.wamp.interfaces;
 
+import io.crossbar.autobahn.wamp.types.TransportOptions;
+
 public interface ITransport {
 
     void send(byte[] payload, boolean isBinary);
 
     void connect(ITransportHandler transportHandler) throws Exception;
+
+    void connect(ITransportHandler transportHandler, TransportOptions options) throws Exception;
 
     boolean isOpen();
 

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/transports/AndroidWebSocket.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/transports/AndroidWebSocket.java
@@ -20,9 +20,11 @@ import io.crossbar.autobahn.wamp.interfaces.ITransportHandler;
 import io.crossbar.autobahn.wamp.serializers.CBORSerializer;
 import io.crossbar.autobahn.wamp.serializers.JSONSerializer;
 import io.crossbar.autobahn.wamp.serializers.MessagePackSerializer;
+import io.crossbar.autobahn.wamp.types.TransportOptions;
 import io.crossbar.autobahn.websocket.WebSocketConnection;
 import io.crossbar.autobahn.websocket.WebSocketConnectionHandler;
 import io.crossbar.autobahn.websocket.types.ConnectionResponse;
+import io.crossbar.autobahn.websocket.types.WebSocketOptions;
 
 public class AndroidWebSocket implements ITransport {
 
@@ -60,6 +62,18 @@ public class AndroidWebSocket implements ITransport {
 
     @Override
     public void connect(ITransportHandler transportHandler) throws Exception {
+        connect(transportHandler, new TransportOptions());
+    }
+
+    @Override
+    public void connect(ITransportHandler transportHandler, TransportOptions options)
+            throws Exception {
+
+        WebSocketOptions webSocketOptions = new WebSocketOptions();
+        webSocketOptions.setAutoPingInterval(options.getAutoPingInterval());
+        webSocketOptions.setAutoPingTimeout(options.getAutoPingTimeout());
+        webSocketOptions.setMaxFramePayloadSize(options.getMaxFramePayloadSize());
+
         mConnection.connect(mUri, getSerializers(), new WebSocketConnectionHandler() {
 
             @Override
@@ -103,7 +117,7 @@ public class AndroidWebSocket implements ITransport {
                     e.printStackTrace();
                 }
             }
-        });
+        }, webSocketOptions, null);
     }
 
     @Override

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/transports/NettyWebSocket.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/transports/NettyWebSocket.java
@@ -13,7 +13,6 @@ package io.crossbar.autobahn.wamp.transports;
 
 import java.net.URI;
 import java.util.List;
-import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 
 import javax.net.ssl.SSLException;
@@ -25,6 +24,7 @@ import io.crossbar.autobahn.wamp.interfaces.ITransportHandler;
 import io.crossbar.autobahn.wamp.serializers.CBORSerializer;
 import io.crossbar.autobahn.wamp.serializers.JSONSerializer;
 import io.crossbar.autobahn.wamp.serializers.MessagePackSerializer;
+import io.crossbar.autobahn.wamp.types.TransportOptions;
 import io.crossbar.autobahn.wamp.types.WebSocketOptions;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.buffer.ByteBuf;
@@ -63,32 +63,41 @@ public class NettyWebSocket implements ITransport {
     private NettyWebSocketClientHandler mHandler;
     private final String mUri;
 
-    private Executor mExecutor;
     private WebSocketOptions mOptions;
-    private List<String> mSerializers;
+    private String mSerializers;
 
     public NettyWebSocket(String uri) {
-        mUri = uri;
+        this(uri, (WebSocketOptions) null);
     }
 
     public NettyWebSocket(String uri, List<String> serializers) {
-        mUri = uri;
-        mSerializers = serializers;
+        this(uri, serializers, null);
     }
 
+    @Deprecated
     public NettyWebSocket(String uri, WebSocketOptions options) {
-        this(uri);
-        mOptions = options;
+        this(uri, null, options);
     }
 
+    @Deprecated
     public NettyWebSocket(String uri, List<String> serializers, WebSocketOptions options) {
         mUri = uri;
-        mSerializers = serializers;
-        mOptions = options;
-    }
 
-    private WebSocketOptions getOptions() {
-        return mOptions == null ? new WebSocketOptions() : mOptions;
+        if (serializers == null) {
+            mSerializers = SERIALIZERS_DEFAULT;
+        } else {
+            StringBuilder result = new StringBuilder();
+            for (String serializer: serializers) {
+                result.append(serializer).append(",");
+            }
+            mSerializers = result.toString();
+        }
+
+        if (options == null) {
+            mOptions = new WebSocketOptions();
+        } else {
+            mOptions = options;
+        }
     }
 
     private int validateURIAndGetPort(URI uri) {
@@ -112,19 +121,26 @@ public class NettyWebSocket implements ITransport {
                 InsecureTrustManagerFactory.INSTANCE).build() : null;
     }
 
-    private String getSerializers() {
-        if (mSerializers != null) {
-            StringBuilder result = new StringBuilder();
-            for (String serializer: mSerializers) {
-                result.append(serializer).append(",");
-            }
-            return result.toString();
-        }
-        return SERIALIZERS_DEFAULT;
+    @Override
+    public void connect(ITransportHandler transportHandler) throws Exception {
+        connect(transportHandler, new TransportOptions());
     }
 
     @Override
-    public void connect(ITransportHandler transportHandler) throws Exception {
+    public void connect(ITransportHandler transportHandler, TransportOptions options)
+            throws Exception {
+
+        if (options == null) {
+            if (mOptions == null) {
+                options = new TransportOptions();
+            } else {
+                options = new TransportOptions();
+                options.setAutoPingInterval(mOptions.getAutoPingInterval());
+                options.setAutoPingTimeout(mOptions.getAutoPingTimeout());
+                options.setMaxFramePayloadSize(mOptions.getMaxFramePayloadSize());
+            }
+        }
+
         URI uri;
         uri = new URI(mUri);
         int port = validateURIAndGetPort(uri);
@@ -134,14 +150,16 @@ public class NettyWebSocket implements ITransport {
         final SslContext sslContext = getSSLContext(scheme);
 
         WebSocketClientHandshaker handshaker = WebSocketClientHandshakerFactory.newHandshaker(
-                uri, WebSocketVersion.V13, getSerializers(), true,
-                new DefaultHttpHeaders(), getOptions().getMaxFramePayloadSize());
-        mHandler = new NettyWebSocketClientHandler(handshaker,this, transportHandler);
+                uri, WebSocketVersion.V13, mSerializers, true,
+                new DefaultHttpHeaders(), options.getMaxFramePayloadSize());
+        mHandler = new NettyWebSocketClientHandler(handshaker, this, transportHandler);
 
         EventLoopGroup group = new NioEventLoopGroup();
         Bootstrap bootstrap = new Bootstrap();
         bootstrap.group(group);
         bootstrap.channel(NioSocketChannel.class);
+
+        TransportOptions opt = options;
         bootstrap.handler(new ChannelInitializer<SocketChannel>() {
             @Override
             protected void initChannel(SocketChannel ch) throws Exception {
@@ -153,7 +171,9 @@ public class NettyWebSocket implements ITransport {
                         new HttpClientCodec(),
                         new HttpObjectAggregator(8192),
                         WebSocketClientCompressionHandler.INSTANCE,
-                        new IdleStateHandler(15, 10, 20, TimeUnit.SECONDS),
+                        new IdleStateHandler(
+                                opt.getAutoPingInterval() + opt.getAutoPingTimeout(),
+                                opt.getAutoPingInterval(), 0, TimeUnit.SECONDS),
                         mHandler);
             }
         });

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/types/TransportOptions.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/types/TransportOptions.java
@@ -1,0 +1,64 @@
+///////////////////////////////////////////////////////////////////////////////
+//
+//   AutobahnJava - http://crossbar.io/autobahn
+//
+//   Copyright (c) Crossbar.io Technologies GmbH and contributors
+//
+//   Licensed under the MIT License.
+//   http://www.opensource.org/licenses/mit-license.php
+//
+///////////////////////////////////////////////////////////////////////////////
+
+package io.crossbar.autobahn.wamp.types;
+
+public class TransportOptions {
+    private int mMaxFramePayloadSize;
+    private int mAutoPingInterval;
+    private int mAutoPingTimeout;
+
+    public TransportOptions() {
+        mMaxFramePayloadSize = 128 * 1024;
+        mAutoPingInterval = 10;
+        mAutoPingTimeout = 5;
+    }
+
+    /**
+     * Set maximum frame payload size that will be accepted
+     * when receiving.
+     * <p>
+     * DEFAULT: 4MB
+     *
+     * @param size Maximum size in octets for frame payload.
+     */
+    public void setMaxFramePayloadSize(int size) {
+        if (size > 0) {
+            mMaxFramePayloadSize = size;
+        }
+    }
+
+    /**
+     * Get maximum frame payload size that will be accepted
+     * when receiving.
+     *
+     * @return Maximum size in octets for frame payload.
+     */
+    public int getMaxFramePayloadSize() {
+        return mMaxFramePayloadSize;
+    }
+
+    public void setAutoPingInterval(int seconds) {
+        mAutoPingInterval = seconds;
+    }
+
+    public int getAutoPingInterval() {
+        return mAutoPingInterval;
+    }
+
+    public void setAutoPingTimeout(int seconds) {
+        mAutoPingTimeout = seconds;
+    }
+
+    public int getAutoPingTimeout() {
+        return mAutoPingTimeout;
+    }
+}

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/types/WebSocketOptions.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/types/WebSocketOptions.java
@@ -11,35 +11,7 @@
 
 package io.crossbar.autobahn.wamp.types;
 
-public class WebSocketOptions {
+@Deprecated
+public class WebSocketOptions extends TransportOptions {
 
-    private int mMaxFramePayloadSize;
-
-    public WebSocketOptions() {
-        mMaxFramePayloadSize = 128 * 1024;
-    }
-
-    /**
-     * Set maximum frame payload size that will be accepted
-     * when receiving.
-     * <p>
-     * DEFAULT: 4MB
-     *
-     * @param size Maximum size in octets for frame payload.
-     */
-    public void setMaxFramePayloadSize(int size) {
-        if (size > 0) {
-            mMaxFramePayloadSize = size;
-        }
-    }
-
-    /**
-     * Get maximum frame payload size that will be accepted
-     * when receiving.
-     *
-     * @return Maximum size in octets for frame payload.
-     */
-    public int getMaxFramePayloadSize() {
-        return mMaxFramePayloadSize;
-    }
 }

--- a/autobahn/src/main/java/io/crossbar/autobahn/websocket/types/WebSocketOptions.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/websocket/types/WebSocketOptions.java
@@ -29,7 +29,8 @@ public class WebSocketOptions {
     private boolean mMaskClientFrames;
     private int mReconnectInterval;
     private String[] mTlsProtocols;
-
+    private int mAutoPingInterval;
+    private int mAutoPingTimeout;
 
     /**
      * Construct default options.
@@ -46,6 +47,8 @@ public class WebSocketOptions {
         mMaskClientFrames = true;
         mReconnectInterval = 0;  // no reconnection by default
         mTlsProtocols = null;
+        mAutoPingInterval = 10;
+        mAutoPingTimeout = 5;
     }
 
     /**
@@ -65,6 +68,8 @@ public class WebSocketOptions {
         mMaskClientFrames = other.mMaskClientFrames;
         mReconnectInterval = other.mReconnectInterval;
         mTlsProtocols = other.mTlsProtocols;
+        mAutoPingInterval = other.mAutoPingInterval;
+        mAutoPingTimeout = other.mAutoPingTimeout;
     }
 
     /**
@@ -280,5 +285,21 @@ public class WebSocketOptions {
      */
     public void setTLSEnabledProtocols(String[] protocols) {
         this.mTlsProtocols = protocols;
+    }
+
+    public void setAutoPingInterval(int seconds) {
+        mAutoPingInterval = seconds;
+    }
+
+    public int getAutoPingInterval() {
+        return mAutoPingInterval;
+    }
+
+    public void setAutoPingTimeout(int seconds) {
+        mAutoPingTimeout = seconds;
+    }
+
+    public int getAutoPingTimeout() {
+        return mAutoPingTimeout;
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -19,12 +19,12 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.0'
     }
     // Android specific dependencies.
     if (project.properties.get('buildPlatform', 'android') == 'android') {
         dependencies {
-            classpath 'com.android.tools.build:gradle:3.0.1'
+            classpath 'com.android.tools.build:gradle:3.1.0'
             classpath 'com.github.dcendents:android-maven-gradle-plugin:2.0'
         }
     }

--- a/demo-gallery/build.gradle
+++ b/demo-gallery/build.gradle
@@ -2,12 +2,12 @@ apply plugin: project.PLATFORM == project.PLATFORM_NETTY ? project.PLUGIN_JAVA_A
 
 if (plugins.hasPlugin(project.PLUGIN_ANDROID_APP)) {
     android {
-        compileSdkVersion 26
-        buildToolsVersion '26.0.2'
+        compileSdkVersion 27
+        buildToolsVersion '27.0.3'
 
         defaultConfig {
             minSdkVersion 24
-            targetSdkVersion 26
+            targetSdkVersion 27
         }
         buildTypes {
             release {
@@ -32,7 +32,7 @@ if (plugins.hasPlugin(project.PLUGIN_ANDROID_APP)) {
 
     dependencies {
         implementation project(path: ':autobahn')
-        implementation 'com.android.support:appcompat-v7:26.1.0'
+        implementation 'com.android.support:appcompat-v7:27.1.0'
     }
 } else {
     mainClassName = 'io.crossbar.autobahn.demogallery.netty.Main'


### PR DESCRIPTION
Introduces a new class `TransportOptions` to not be WebSocket specific as we may have a raw socket based transport in future.

Fixes https://github.com/crossbario/autobahn-java/issues/383