### PR TITLE
Don't call onLeave listener twice in case of normal GoodBye

### DIFF
--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/Session.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/Session.java
@@ -225,6 +225,9 @@ public class Session implements ISession, ITransportHandler {
 
     @Override
     public void onLeave(CloseDetails details) {
+        if (mState == STATE_DISCONNECTED) {
+            return;
+        }
         LOGGER.d("onLeave(), reason=" + details.reason);
 
         List<CompletableFuture<?>> futures = new ArrayList<>();

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/transports/AndroidWebSocket.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/transports/AndroidWebSocket.java
@@ -100,17 +100,16 @@ public class AndroidWebSocket implements ITransport {
 
             @Override
             public void onClose(int code, String reason) {
-                switch (code) {
-                    case IWebSocketConnectionHandler.CLOSE_CONNECTION_LOST:
-                        transportHandler.onLeave(
-                                new CloseDetails(CloseDetails.REASON_TRANSPORT_LOST, null));
-                        break;
-                    default:
-                        transportHandler.onLeave(
-                                new CloseDetails(CloseDetails.REASON_DEFAULT, null));
+                String closeReason;
+                if (code == IWebSocketConnectionHandler.CLOSE_CONNECTION_LOST) {
+                    closeReason = CloseDetails.REASON_TRANSPORT_LOST;
+                } else {
+                    closeReason = CloseDetails.REASON_DEFAULT;
                 }
+                transportHandler.onLeave(new CloseDetails(closeReason, null));
                 LOGGER.d(String.format("Disconnected, code=%s, reasons=%s", code, reason));
-                transportHandler.onDisconnect(code == 1000);
+                transportHandler.onDisconnect(code == IWebSocketConnectionHandler.CLOSE_NORMAL
+                        || code == 1000);
             }
 
             @Override


### PR DESCRIPTION
* Ensure the onLeave listener is called only once
* Interpret WebSocket close code `1` as "clean" because in our AndroidWebSocket implementation we have custom error codes.