### PR TITLE
FIX: Netty: close netty connection when all threads terminated

### DIFF
--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/transports/NettyWebSocket.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/transports/NettyWebSocket.java
@@ -157,7 +157,11 @@ public class NettyWebSocket implements ITransport {
                 new DefaultHttpHeaders(), options.getMaxFramePayloadSize());
         mHandler = new NettyWebSocketClientHandler(handshaker, this, transportHandler);
 
-        EventLoopGroup group = new NioEventLoopGroup();
+        EventLoopGroup group = new NioEventLoopGroup(0, r -> {
+            Thread t = Executors.defaultThreadFactory().newThread(r);
+            t.setDaemon(true);
+            return t;
+        });
         Bootstrap bootstrap = new Bootstrap();
         bootstrap.group(group);
         bootstrap.channel(NioSocketChannel.class);


### PR DESCRIPTION
In a multi-threaded program, the netty connection (nioEventLoopGroup thread) does not closing when all other threads are terminated.