### PR TITLE
Update netty docker image to use Java11

### DIFF
--- a/docker/Dockerfile.netty
+++ b/docker/Dockerfile.netty
@@ -1,4 +1,4 @@
-FROM ubuntu
+FROM ubuntu:20.04
 
 MAINTAINER The Crossbar.io Project <support@crossbario.com>
 
@@ -21,12 +21,12 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 USER root
 
 ENV DEBIAN_FRONTEND noninteractive
-ENV GRADLE_VERSION 4.7
+ENV GRADLE_VERSION 6.4.1
 
 WORKDIR /workspace
 
 RUN    apt update \
-    && apt install unzip wget openjdk-8-jdk-headless -y \
+    && apt install unzip wget openjdk-11-jdk-headless -y \
     && apt clean \
     && rm -rf /var/lib/apt/lists/
 


### PR DESCRIPTION
* Based on Ubuntu 20.04
* Use Java11 LTS instead of 8

I built the image locally and ran the tests and it seems the netty backend works fine with Java11.

OTH: I cannot publish the new docker image, seems I'd need rights.