### PR TITLE
WebSocket: reuse message byte array instead of recreating

### DIFF
--- a/autobahn/src/main/java/io/crossbar/autobahn/websocket/WebSocketReader.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/websocket/WebSocketReader.java
@@ -287,6 +287,13 @@ class WebSocketReader extends Thread {
                     System.arraycopy(mMessageData, mFrameHeader.mHeaderLen, framePayload, 0, mFrameHeader.mPayloadLen);
                 }
 
+                // mMessageData = Arrays.copyOfRange(mMessageData, mFrameHeader.mTotalLen, mMessageData.length + mFrameHeader.mTotalLen);
+                // We were previously recreating the message data array for each fragment, that is resource hungry.
+                // Imagine having set the message max payload size to 16M, each time we receive a new frame for a
+                // message, we were creating a new byte[] of 16M.
+                //
+                // Now imagine if the sender sends a message of size 4M in fragments of 64, we will be creating a byte[16M]
+                // 4 * 2**20 / 64 times which is 65536, that's one hell of a pressure on the GC.
                 System.arraycopy(mMessageData, mFrameHeader.mTotalLen, mMessageData, 0, mMessageData.length - mFrameHeader.mTotalLen);
                 mPosition -= mFrameHeader.mTotalLen;
 

--- a/autobahn/src/main/java/io/crossbar/autobahn/websocket/WebSocketReader.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/websocket/WebSocketReader.java
@@ -286,7 +286,8 @@ class WebSocketReader extends Thread {
                     framePayload = new byte[mFrameHeader.mPayloadLen];
                     System.arraycopy(mMessageData, mFrameHeader.mHeaderLen, framePayload, 0, mFrameHeader.mPayloadLen);
                 }
-                mMessageData = Arrays.copyOfRange(mMessageData, mFrameHeader.mTotalLen, mMessageData.length + mFrameHeader.mTotalLen);
+
+                System.arraycopy(mMessageData, mFrameHeader.mTotalLen, mMessageData, 0, mMessageData.length - mFrameHeader.mTotalLen);
                 mPosition -= mFrameHeader.mTotalLen;
 
                 if (mFrameHeader.mOpcode > 7) {
@@ -534,7 +535,7 @@ class WebSocketReader extends Thread {
                 /// \FIXME verify handshake from server
                 Map<String, String> handshakeParams = parseHttpHeaders(Arrays.copyOfRange(headers, 1, headers.length));
 
-                mMessageData = Arrays.copyOfRange(mMessageData, pos + 4, mMessageData.length + pos + 4);
+                System.arraycopy(mMessageData, pos + 4, mMessageData, 0, mMessageData.length - (pos + 4));
                 mPosition -= pos + 4;
 
                 if (!serverError) {

--- a/demo-gallery/src/main/java/io/crossbar/autobahn/demogallery/android/TestSuiteClientActivity.java
+++ b/demo-gallery/src/main/java/io/crossbar/autobahn/demogallery/android/TestSuiteClientActivity.java
@@ -64,6 +64,7 @@ public class TestSuiteClientActivity extends AppCompatActivity implements View.O
         mOptions.setReceiveTextMessagesRaw(true);
         mOptions.setMaxMessagePayloadSize(16 * 1024 * 1024);
         mOptions.setMaxFramePayloadSize(16 * 1024 * 1024);
+        mOptions.setAutoPingInterval(0);
     }
 
     private void loadPrefs() {


### PR DESCRIPTION
This reduces the GC pressure substantially, instead of creating a new byte array for each WebSocket frame, we just reuse the existing one.

This improves performance of websocket tests that send payload in small fragments.