### PR TITLE
Support customize subscribe.options && compatible with null value for type int

### DIFF
--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/types/SubscribeOptions.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/types/SubscribeOptions.java
@@ -28,6 +28,10 @@ public class SubscribeOptions extends HashMap<String, Object> {
         super(origin);
     }
 
+    public SubscribeOptions() {
+        super();
+    }
+
     public void putMatch(String match) {
         put(KEY_MATCH, match);
     }

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/types/SubscribeOptions.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/types/SubscribeOptions.java
@@ -11,14 +11,47 @@
 
 package io.crossbar.autobahn.wamp.types;
 
-public class SubscribeOptions {
-    public String match;
-    public boolean details;
-    public boolean getRetained;
+import java.util.HashMap;
+import java.util.Map;
 
-    public SubscribeOptions(String match, boolean details, boolean getRetained) {
-        this.match = match;
-        this.details = details;
-        this.getRetained = getRetained;
+public class SubscribeOptions extends HashMap<String, Object> {
+
+    public static final String KEY_MATCH = "match";
+    public static final String KEY_GET_RETAINED = "get_retained";
+
+    public SubscribeOptions(String match, boolean getRetained) {
+        putMatch(match);
+        putGetRetained(getRetained);
     }
+
+    public SubscribeOptions(Map<String, Object> origin) {
+        super(origin);
+    }
+
+    public void putMatch(String match) {
+        put(KEY_MATCH, match);
+    }
+
+    public void putGetRetained(boolean getRetained) {
+        put(KEY_GET_RETAINED, getRetained);
+    }
+
+    public String getMatch() {
+        Object value = get(KEY_MATCH);
+        return value instanceof String ? (String) value : null;
+    }
+
+    public Boolean getRetained() {
+        Object value = get(KEY_GET_RETAINED);
+        return value instanceof Boolean ? (Boolean) value : null;
+    }
+
+    public void removeMatch() {
+        remove(KEY_MATCH);
+    }
+
+    public void removeGetRetained() {
+        remove(KEY_GET_RETAINED);
+    }
+
 }

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/utils/MessageUtil.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/utils/MessageUtil.java
@@ -67,6 +67,9 @@ public class MessageUtil {
 		if (object instanceof Integer) {
 			return (int) object;
 		}
-		return (long) object;
+		if (object instanceof Long) {
+		    return (Long) object;
+        }
+		return 0;
     }
 }


### PR DESCRIPTION
1. according to [https://wamp-proto.org/_static/gen/wamp_latest.html#subscribe-0](https://wamp-proto.org/_static/gen/wamp_latest.html#subscribe-0), message SUBSCRIBE.Options is a dict that allows to provide additional subscription request details in a extensible way
2. make java type int/long compatible with null value of wamp type int