### PR TITLE
enable debug log at runtime

### DIFF
--- a/autobahn/src/main/java/io/crossbar/autobahn/Autobahn.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/Autobahn.java
@@ -1,0 +1,11 @@
+package io.crossbar.autobahn;
+
+import io.crossbar.autobahn.utils.Globals;
+
+public abstract class Autobahn {
+
+    public static void enableDebugLog(boolean enable) {
+        Globals.DEBUG = enable;
+    }
+
+}

--- a/autobahn/src/main/java/io/crossbar/autobahn/utils/Globals.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/utils/Globals.java
@@ -13,5 +13,6 @@ package io.crossbar.autobahn.utils;
 
 public class Globals {
     // Default set to true, this is set to false by the release script.
-    public static final boolean DEBUG = true;
+    // And change by Autobahn.enableDebugLog at the runtime
+    public static volatile boolean DEBUG = true;
 }


### PR DESCRIPTION
It's nice to enable debug log at runtime instead of building library from source, like most library do