### PR TITLE
Tag created socket on Android

### DIFF
--- a/autobahn/src/main/java/io/crossbar/autobahn/websocket/WebSocketConnection.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/websocket/WebSocketConnection.java
@@ -11,6 +11,8 @@
 
 package io.crossbar.autobahn.websocket;
 
+import android.net.TrafficStats;
+
 import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -55,6 +57,8 @@ import io.crossbar.autobahn.websocket.types.WebSocketOptions;
 import static io.crossbar.autobahn.websocket.utils.Platform.selectThreadMessenger;
 
 public class WebSocketConnection implements IWebSocket {
+
+    private static final int THREAD_SOCKET_TAG = 1000;
 
     private static final IABLogger LOGGER = ABLogger.getLogger(WebSocketConnection.class.getName());
 
@@ -120,6 +124,9 @@ public class WebSocketConnection implements IWebSocket {
         public void run() {
             Thread.currentThread().setName("WebSocketConnector");
 
+            // tag the thread for socket traffic monitoring
+            TrafficStats.setThreadStatsTag(THREAD_SOCKET_TAG);
+
 			/*
              * connect TCP socket
 			 */
@@ -143,6 +150,9 @@ public class WebSocketConnection implements IWebSocket {
                 // options
                 mSocket.setSoTimeout(mOptions.getSocketReceiveTimeout());
                 mSocket.setTcpNoDelay(mOptions.getTcpNoDelay());
+
+                // tag socket for monitoring
+                TrafficStats.tagSocket(mSocket);
 
             } catch (IOException e) {
                 mMessenger.notify(new CannotConnect(e.getMessage()));


### PR DESCRIPTION
This PR fixes #519 

The warning does not appear on Android anymore.

Building the aar still works from Android Studio.

Running `make build` works fine a generates a lib.

I am not sure however about the `import android.net.TrafficStats;`. I would say that if it compiles, it should run, but I did/could not test the Netty version.