### PR TITLE
Datatype module support to make Jackson recognize Java 8 Date & Time

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,9 +15,10 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
-          java-version: 1.8
+          distribution: 'corretto'
+          java-version: 11
 
       - name: Setup Android SDK
         uses: android-actions/setup-android@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up JDK 1.8
+      - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
           distribution: 'corretto'

--- a/autobahn/build.gradle
+++ b/autobahn/build.gradle
@@ -35,6 +35,7 @@ dependencies {
         implementation 'org.web3j:abi:4.6.0'
         implementation 'org.web3j:utils:4.6.0'
         implementation 'org.json:json:20210307'
+        implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.12.3'
     }
     if (IS_NETTY) {
         implementation 'io.netty:netty-codec-http:4.1.63.Final'

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/interfaces/ISerializer.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/interfaces/ISerializer.java
@@ -15,6 +15,7 @@ import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
@@ -32,6 +33,9 @@ public abstract class ISerializer {
 
     public ISerializer(JsonFactory factor) {
         mapper = new ObjectMapper(factor);
+        mapper.findAndRegisterModules();
+        mapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
+        mapper.configure(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE, false);
         mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     }
 


### PR DESCRIPTION
Hi! There is no feature for [parsing Java 8 Date & Time formats](https://github.com/FasterXML/jackson-modules-java8/tree/2.16/datetime).
 
IIf we try to deserialize string obj "2023-10-06T18:29:50.138+03:00" to object of class OffsetDateTime, we have the exception "com.fasterxml.jackson.databind.exc.InvalidDefinitionException: Java 8 date/time type `java.time.OffsetDateTime` not supported by default: add Module "com.fasterxml.jackson.datatype:jackson-datatype-jsr310" to enable handling".

So this PR add this feature to your wonderful library